### PR TITLE
tests: fix order-dependent suite — pin law years, stop TAX_YEAR leakage

### DIFF
--- a/rework2-plan.md
+++ b/rework2-plan.md
@@ -1,0 +1,158 @@
+# Rework2 Plan — architecture-first rebuild of per-depot-fifo from main
+
+Successor of `rework-plan.md`. That plan kept the rearchitecture partially optional
+("applied opportunistically") and sequenced the two engine seams (old B7a/B8a) AFTER the
+features — which twice let execution degenerate into replaying the old branch's commits.
+This plan makes the architecture **mandatory, early, and integral**: seams first, features
+built on the seams, per-Depot flip last as a small delta.
+
+Relationship to other artifacts:
+- `legal-review-todo.md` — findings F1–F6, action list, coverage gaps (unchanged input).
+- `rework` branch — the completed feature-first port (17 commits, parity-proven vs the
+  oracle). It stays untouched as the **standalone-PR packaging**; `rework2` is the
+  **architecture-first packaging**. After the parity gate the user decides which branch
+  carries Phase C and the upstream PRs.
+- `oracle/per-depot-fifo` tag — immutable output oracle.
+
+---
+
+## Ground rules (binding)
+
+**0. Existing work stays untouched.**
+- All work happens on branch `rework2`, recreated from `main`. No existing branch
+  (`per-depot-fifo`, `main`, `rework`, …) is rebased, force-pushed, amended, or deleted.
+- `oracle/per-depot-fifo` is the immutable parity target.
+
+**1. Reuse policy (pinned — this ambiguity caused the earlier blowups).**
+- MAY be ported and re-expressed on the new architecture: architecture-independent content
+  authored during the rework effort — the Phase-A legal-fix tests, parser fixes,
+  VP modules (`processing/vp_*`, `identification/*provider*`), bond-maturity mapping,
+  PDF improvements, and all test files (tests are the spec).
+- MUST be written fresh against the seams: the ENGINE core — ledger keying, replay,
+  per-Depot logic, transfer handling. The oracle's tests serve as the black-box spec.
+- NO wholesale commit replay from `rework` or `per-depot-fifo`.
+
+**2. One commit = one issue, fully e2e.**
+- Each commit contains requirement/reference updates, tests, and code together.
+- Commit message: one-line issue, body with legal basis (statute + `reference/` file).
+- Bugfix tests are demonstrated red-first on the pre-fix tree.
+
+**3. Every commit is green.**
+- `uv run pytest -q` passes at every commit — real exit code, never piped through `tail`.
+- Final whole-history sweep: check out each commit (pin `src/config.py` to that commit's
+  `config_example.py`) and run the suite.
+
+**4. Architecture is mandatory and comes first.**
+- The Phase AR items below are binding train items, not guidance. Nothing is
+  "opportunistic".
+- Every AR refactor is no-behavior-change, verified by (a) the full suite and (b) a
+  real-data parity run against its PARENT commit: run
+  `uv run python -m src.main --report-tax-declaration --pdf-output-file …` on
+  `data_import/`, normalize run-random event UUIDs, timestamps and output paths, sort log
+  lines; the diff must be 0 and the non-log report section byte-identical. (Technique
+  proven during the rework parity gate; PDF differs only in CreationDate//ID.)
+
+**5. End state: FULL output parity with the oracle.**
+- After the last Phase-B commit: full parity gate vs `oracle/per-depot-fifo` (console +
+  PDF, same normalization), for the configured tax year and at least one earlier year if
+  data permits.
+- Every diff hunk gets a deep-dive in `parity-log.md`: symptom → root cause →
+  classification. **(a) accepted** only if it is a documented bug in per-depot-fifo
+  (citing a finding in `legal-review-todo.md` or a newly written-up oracle defect);
+  **(b) anything else is a regression** — fix before proceeding, no exceptions.
+- Known candidate (a)-diffs from Phase A: repealed €20k cap lines (F2), §23 leap-year
+  anniversary classification (F3), VP for previously missing Basiszins years (F6) — each
+  individually verified and logged, never waved through. (On the current real data set
+  none of these constellations occur; the rework gate showed zero diffs.)
+
+---
+
+## The commit train (order = build order)
+
+### Phase 0 — trustworthy greens
+
+| # | Issue | Content |
+|---|-------|---------|
+| A1 | Test suite is order-dependent; group 6 not pinned to its law year (F1) | Harness fix (`tests/support/base.py` via pytest monkeypatch), pin group 6 to `tax_year=2024`, ADD the 2025-law scenario set. Port from the rework work (authored fresh there, fits the reuse policy). **First commit.** |
+
+### Phase AR — mandatory architecture (before all features)
+
+Each item: one commit, single-purpose, suite green, parent-parity-checked (rule 4).
+
+| # | Item | Content |
+|---|------|---------|
+| AR0 | Parity tooling + multi-account harness (improvements #10, #9-harness) | `scripts/parity_check.sh`: pipeline run capture, UUID/timestamp normalization, diff; used per-commit from here on. Extend the test harness with multi-account CSV builders (the YAML harness is single-account today; per-depot tests had to hand-roll writers). |
+| AR1 | RunContext — no global mutable config (#1) | `src/utils/run_context.py`: pipeline entry constructs an explicit context (tax_year, precision, rounding mode, registry handles) threaded through engine/processors; `src.config` is read once at the boundary (`main.py`/`pipeline_runner.py`). Tests construct their own context — the F1 bug class and the untracked-config test fragility become impossible. |
+| AR2 | Law-as-data registry + core-vs-form layering (#2, #6) | `src/tax_law/registry.py`: Basiszins table, Teilfreistellung rates, FormYearRules — each entry with statutory citation and effective range; out-of-range lookups fail LOUD. The engine emits year-agnostic `TaxReportingCategory` totals; the registry-driven projection is the only Zeilen-aware layer. Registry↔`reference/` consistency test (generalizes the A5 table test). Absorbs legal fixes **A3** (cap repealed for all years, JStG 2024 retroactive) and **A5** (complete Basiszins 2016–2026 + loud gap) as registry content with red-first tests. |
+| AR3 | HoldingPeriod domain type (#3) | `src/utils/holding_period.py`: §§108 AO, 187 Abs. 1, 188 Abs. 2/3 BGB anniversary arithmetic as a type, property-tested incl. leap years and 29-Feb acquisitions. Absorbs legal fix **A2**: replacing the `<= 365` day-count IS the introduction of this type (red-first leap-year spec). |
+| AR4 | LedgerKey seam + aggregate views (#5) | Ledger registries keyed by `(account_key, asset_id)` with everything on `DEFAULT_ACCOUNT`; explicit `aggregate_view(asset_id)` for per-person consumers (VP, EOY validation, return totals). No behavior change. Keying shape matches the oracle's `(account_key, asset_id)` tuples so the later flip stays oracle-faithful. |
+| AR5 | Unified chronological replayer (#4) | One sorted event stream with registered per-event-type handlers; the SAME loop serves historical reconstruction and current-year processing; securities and currencies share the stream. Intra-day ordering contract documented here (merger before transfer of its output; transfer before merger at destination). No behavior change. Written fresh on main's engine — the biggest new build of the plan; the 7/n bug class (parallel currency replay path) becomes structurally impossible. |
+| AR6 | Data-gap channel (#7) | `src/processing/data_gaps.py`: one collector with a severity policy — fail-fast where income could be understated, warn for evidentiary mismatches; gaps surfaced in the report. Resolves **F4** to fail-fast by construction (B4 plugs into it). |
+| AR7 | Legal-position register (#8, scoped light) | `src/tax_law/legal_positions.py`: entries (position taken, alternative, source) for per-Depot FX, short-FX analogy, Einlagenrückgewähr excess; rendered as report caveats. |
+
+### Phase A remainder — legal fixes not absorbed by AR
+
+| # | Issue | Content |
+|---|-------|---------|
+| A4 | False-confidence tests (F6) | Replace: misnamed negative-gross test (factory contract), CFX_ERR_002 (row must reach the engine; fail-fast `DataIntegrityError` pinned), group-11 soft assert (pin exactly one zero-gain RGL), WHT double-link (two dividends, correct pairing). Port from the rework work. |
+
+(A2 → AR3, A3/A5 → AR2.)
+
+### Phase B — features built ON the architecture
+
+Content ported per reuse policy (rule 1), re-expressed against RunContext / registry /
+replayer / gap channel where they touch those seams.
+
+| # | Issue | Content / seam usage |
+|---|-------|----------------------|
+| B1 | Parser fails on current IBKR export format | Port fix + the regression tests added during rework (repeated headers, extra columns, BASE_SUMMARY). |
+| B2 | Multi-account rows overwrite instead of summing | Port aggregation fix + tests. Per-account recording is NOT here (belongs to B7b). |
+| B3 | Bond maturity (BM) unsupported | Port factory mapping + tests + docs. The synthetic sell flows through the AR5 stream like any trade. |
+| B4 | Vorabpauschale §18 missing (partial-year, deemed inflow Y+1) | Port VP modules/tests; Basiszins via AR2 registry; NAV gaps via AR6 channel (**fail-fast in non-interactive runs — F4 resolved**; adjust the warn-only test accordingly); fixture-label and docstring fixes from the legal review. |
+| B5 | §19 VP deduction missing at disposal | Port per-lot FIFO deduction, only-if-declared cap, provider (prompted-only slice), Z13+Z26 invariant test. |
+| B5g | Glue: auto-compute the V−1 declared VP | Port the auto-compute path + tests (depends on B4+B5). |
+| B6 | PDF Sonstige Kapitalerträge breakdown | Port; reporting only. |
+| B7b | FIFO across depots violates §20 Abs. 4 S. 7 | **Small delta now**: flip LedgerKey from DEFAULT to the events' real `account_id` (plumbing: account on events + per-account recording included here), per-account SoY init/reconciliation; aggregate views keep feeding VP/EOY/totals. Engine logic written fresh on AR4/AR5; oracle's cross-account/propagation tests ported as the spec. |
+| B8b | Depotübertragung not modeled (incl. historical non-EUR cash) | Transfers parser (port) + ONE tax-neutral `InternalTransferEvent` handler (drain/receive, basis+date carry, §43 Abs. 1 S. 5) registered in the AR5 replayer — securities and non-EUR cash share the path by construction. Oracle's transfer/merger/cash-basis/SoY-reconciliation tests ported as the spec; add the bond-maturity-after-transfer composition scenario. |
+
+### → PARITY GATE (rule 5) vs `oracle/per-depot-fifo`.
+
+### Phase C — coverage gaps (unchanged from rework-plan; each one issue)
+
+| # | Gap | Legal basis |
+|---|-----|-------------|
+| C1 | Cash-settled index options (Barausgleich) | §20 Abs. 2 Nr. 3a; BFH VIII R 55/13 |
+| C2 | Cash merger / Barzuzahlung / spin-off | §20 Abs. 4a S. 1–2, 7 |
+| C3 | Forward split (imported, never tested) | §20 Abs. 4a |
+| C4 | CFD lifecycle | §20 Abs. 2 Nr. 3 |
+| C5 | Fee cashflows consuming currency lots | BMF FX 2022 Rz. 131 |
+| C6 | WHT → Zeile 41, treaty-capped | §32d Abs. 5, §34c EStG |
+| C7 | Stückzinsen | §20 Abs. 1 Nr. 7; BMF Einzelfragen |
+| C8 | Einlagenrückgewähr excess (F5) — **decision PR**, confirm treatment first | §20 Abs. 1 Nr. 1 S. 3; BMF Rz. 92 |
+
+Phase C lands on whichever branch the user picks after the gate (`rework` or `rework2`).
+New-test rule from here on (#9): every NEW behavior test carries a `legal_basis` reference
+(YAML specs where the spec-runner pattern fits).
+
+---
+
+## Packaging impact (honest trade-off)
+
+Architecture-first breaks the "14 standalone PRs off plain main" property of
+`rework-plan.md`: Phase-B features now depend on AR commits. The two packagings coexist:
+
+- `rework` — standalone-first PRs, feature code identical to the oracle, parity-proven.
+- `rework2` — architecture-first train: better structure, cheaper Phase C, but PRs form a
+  deeper stack (AR seams precede features).
+
+The maintainer-communication mechanics from `rework-plan.md` (tracking issue, per-PR
+template, stack handling) apply to whichever branch is chosen.
+
+---
+
+## Verification
+
+- Per commit: full suite green (real exit code); red-first for every bugfix.
+- Per AR/engine commit: parent-parity run (rule 4) — normalized diff 0 on real data.
+- Final: parity gate vs oracle (rule 5) + whole-history green sweep + `parity-log.md`
+  entries for every hunk (only proven oracle bugs acceptable).

--- a/tests/fixtures/loss_offsetting_data.py
+++ b/tests/fixtures/loss_offsetting_data.py
@@ -14,6 +14,14 @@ Key Principles:
 - Conceptual Summaries: Net balances, €20k derivative cap configurable
 - Fund income: Separate pot, NOT in Z19 or "Other Capital Income"
 
+LAW YEAR: LOSS_OFFSETTING_TESTS encodes the VZ <= 2024 Anlage KAP form structure
+(§20 Abs. 6 EStG before JStG 2024 form changes): Z21/Z24 carry derivative
+gains/losses separately and Z19 does NOT subtract derivative losses. The runner
+must pin tax_year=2024 for these. The VZ >= 2025 structure (Z21/Z24 removed,
+Z19 subtracts derivative losses, Z22 includes them — see
+reference/tax-law/estg-20-abs6-verlustverrechnung.md) is encoded separately in
+LOSS_OFFSETTING_TESTS_2025 at the bottom of this file.
+
 This module defines test scenarios for tax reporting aggregation and loss offsetting logic.
 Uses Python dataclasses as an executable specification format.
 """
@@ -947,6 +955,157 @@ LOSS_OFFSETTING_TESTS: List[LossOffsettingTestCase] = [
             conceptual_net_derivatives_capped=D("0.00"),
             conceptual_net_p23_estg=D("0.00"),
             conceptual_fund_income_net_taxable=D("-85.00"),
+        ),
+    ),
+]
+
+
+# =============================================================================
+# VZ >= 2025 scenarios — Anlage KAP after JStG 2024
+# =============================================================================
+# Legal basis (reference/tax-law/estg-20-abs6-verlustverrechnung.md, "Tax Year
+# >= 2025"): the Verlustverrechnungsbeschraenkung for Termingeschaefte was
+# abolished, the 2025 form drops Zeilen 21/24, derivative gains AND losses flow
+# through Zeile 19, and Zeile 22 includes derivative losses alongside other
+# non-stock losses. No €20k cap exists (JStG 2024, retroactive for open cases),
+# so conceptual capped == uncapped.
+#
+# All expected values below are hand-computed from the inputs against that form
+# structure — they are NOT derived from the engine formula.
+
+LOSS_OFFSETTING_TESTS_2025: List[LossOffsettingTestCase] = [
+
+    LossOffsettingTestCase(
+        id="LO25_TERM_001",
+        description="2025: derivative gains only - flow into Z19, Z21 removed",
+        inputs=GrossPotComponents(term_g=D("5000")),
+        expected=ExpectedReportingFigures(
+            form_kap_z19_auslaendische_net=D("5000.00"),
+            form_kap_z20_aktien_g=D("0.00"),
+            form_kap_z21_derivate_g=D("0.00"),   # line removed from 2025 form
+            form_kap_z22_sonstige_v=D("0.00"),
+            form_kap_z23_aktien_v=D("0.00"),
+            form_kap_z24_derivate_v=D("0.00"),   # line removed from 2025 form
+            form_so_z54_p23_net_gv=D("0.00"),
+            conceptual_net_other_income=D("0.00"),
+            conceptual_net_stocks=D("0.00"),
+            conceptual_net_derivatives_uncapped=D("5000.00"),
+            conceptual_net_derivatives_capped=D("5000.00"),
+            conceptual_net_p23_estg=D("0.00"),
+            conceptual_fund_income_net_taxable=D("0.00"),
+        ),
+    ),
+
+    LossOffsettingTestCase(
+        id="LO25_TERM_002",
+        description="2025: derivative losses subtracted in Z19, included in Z22",
+        inputs=GrossPotComponents(term_v=D("15000")),
+        expected=ExpectedReportingFigures(
+            form_kap_z19_auslaendische_net=D("-15000.00"),  # NOW subtracted
+            form_kap_z20_aktien_g=D("0.00"),
+            form_kap_z21_derivate_g=D("0.00"),
+            form_kap_z22_sonstige_v=D("15000.00"),          # NOW included
+            form_kap_z23_aktien_v=D("0.00"),
+            form_kap_z24_derivate_v=D("0.00"),
+            form_so_z54_p23_net_gv=D("0.00"),
+            conceptual_net_other_income=D("0.00"),
+            conceptual_net_stocks=D("0.00"),
+            conceptual_net_derivatives_uncapped=D("-15000.00"),
+            conceptual_net_derivatives_capped=D("-15000.00"),
+            conceptual_net_p23_estg=D("0.00"),
+            conceptual_fund_income_net_taxable=D("0.00"),
+        ),
+    ),
+
+    LossOffsettingTestCase(
+        id="LO25_TERM_004",
+        description="2025: derivative loss above the former €20k threshold - NO cap",
+        notes="JStG 2024 abolished §20 Abs. 6 S. 5 a.F.; full loss offsets.",
+        inputs=GrossPotComponents(term_v=D("30000")),
+        expected=ExpectedReportingFigures(
+            form_kap_z19_auslaendische_net=D("-30000.00"),
+            form_kap_z20_aktien_g=D("0.00"),
+            form_kap_z21_derivate_g=D("0.00"),
+            form_kap_z22_sonstige_v=D("30000.00"),
+            form_kap_z23_aktien_v=D("0.00"),
+            form_kap_z24_derivate_v=D("0.00"),
+            form_so_z54_p23_net_gv=D("0.00"),
+            conceptual_net_other_income=D("0.00"),
+            conceptual_net_stocks=D("0.00"),
+            conceptual_net_derivatives_uncapped=D("-30000.00"),
+            conceptual_net_derivatives_capped=D("-30000.00"),  # NOT capped in 2025
+            conceptual_net_p23_estg=D("0.00"),
+            conceptual_fund_income_net_taxable=D("0.00"),
+        ),
+    ),
+
+    LossOffsettingTestCase(
+        id="LO25_TERM_007",
+        description="2025: derivative gains and large losses net fully in Z19",
+        inputs=GrossPotComponents(term_g=D("5000"), term_v=D("30000")),
+        expected=ExpectedReportingFigures(
+            form_kap_z19_auslaendische_net=D("-25000.00"),  # 5000 - 30000
+            form_kap_z20_aktien_g=D("0.00"),
+            form_kap_z21_derivate_g=D("0.00"),
+            form_kap_z22_sonstige_v=D("30000.00"),
+            form_kap_z23_aktien_v=D("0.00"),
+            form_kap_z24_derivate_v=D("0.00"),
+            form_so_z54_p23_net_gv=D("0.00"),
+            conceptual_net_other_income=D("0.00"),
+            conceptual_net_stocks=D("0.00"),
+            conceptual_net_derivatives_uncapped=D("-25000.00"),
+            conceptual_net_derivatives_capped=D("-25000.00"),
+            conceptual_net_p23_estg=D("0.00"),
+            conceptual_fund_income_net_taxable=D("0.00"),
+        ),
+    ),
+
+    LossOffsettingTestCase(
+        id="LO25_MIX_001",
+        description="2025: all pots active - Z19 nets everything except funds/§23",
+        notes="Z19 = 2000-500+3000-4000+1000-1500 = 0; Z22 = 1500+4000 = 5500.",
+        inputs=GrossPotComponents(
+            akt_g=D("2000"), akt_v=D("500"),
+            term_g=D("3000"), term_v=D("4000"),
+            sonst_g=D("1000"), sonst_v=D("1500"),
+            p23_g=D("800"), p23_v=D("200"),
+        ),
+        expected=ExpectedReportingFigures(
+            form_kap_z19_auslaendische_net=D("0.00"),
+            form_kap_z20_aktien_g=D("2000.00"),
+            form_kap_z21_derivate_g=D("0.00"),
+            form_kap_z22_sonstige_v=D("5500.00"),
+            form_kap_z23_aktien_v=D("500.00"),
+            form_kap_z24_derivate_v=D("0.00"),
+            form_so_z54_p23_net_gv=D("600.00"),
+            conceptual_net_other_income=D("-500.00"),
+            conceptual_net_stocks=D("1500.00"),
+            conceptual_net_derivatives_uncapped=D("-1000.00"),
+            conceptual_net_derivatives_capped=D("-1000.00"),
+            conceptual_net_p23_estg=D("600.00"),
+            conceptual_fund_income_net_taxable=D("0.00"),
+        ),
+    ),
+
+    LossOffsettingTestCase(
+        id="LO25_FUND_001",
+        description="2025: fund income still excluded from Z19 (KAP-INV, not KAP)",
+        fund_income_net_taxable=D("200.00"),
+        inputs=GrossPotComponents(akt_g=D("100"), sonst_g=D("50")),
+        expected=ExpectedReportingFigures(
+            form_kap_z19_auslaendische_net=D("150.00"),  # fund 200 NOT included
+            form_kap_z20_aktien_g=D("100.00"),
+            form_kap_z21_derivate_g=D("0.00"),
+            form_kap_z22_sonstige_v=D("0.00"),
+            form_kap_z23_aktien_v=D("0.00"),
+            form_kap_z24_derivate_v=D("0.00"),
+            form_so_z54_p23_net_gv=D("0.00"),
+            conceptual_net_other_income=D("50.00"),
+            conceptual_net_stocks=D("100.00"),
+            conceptual_net_derivatives_uncapped=D("0.00"),
+            conceptual_net_derivatives_capped=D("0.00"),
+            conceptual_net_p23_estg=D("0.00"),
+            conceptual_fund_income_net_taxable=D("200.00"),
         ),
     ),
 ]

--- a/tests/support/base.py
+++ b/tests/support/base.py
@@ -29,9 +29,16 @@ class FifoTestCaseBase:
 
     @pytest.fixture(autouse=True)
     def setup_test_paths_and_config(self, mock_config_paths, monkeypatch):
-        """Makes mocked config paths available and patches TAX_YEAR for the test instance."""
+        """Makes mocked config paths available and keeps pytest's per-test monkeypatch
+        so _run_pipeline can patch global config with guaranteed undo at test teardown.
+
+        Any patch applied through self._monkeypatch is reverted by pytest when THIS test
+        ends — global state (e.g. src.config.TAX_YEAR) can never leak into later tests
+        or other modules. (The previous hand-rolled MonkeyPatch/teardown pair leaked the
+        patched TAX_YEAR across module boundaries, making test results order-dependent.)"""
         self.config_paths = mock_config_paths
-        
+        self._monkeypatch = monkeypatch
+
         # Ensure cache files don't exist from previous partial runs if they are file based
         classification_cache_path = self.config_paths.get("classification_cache")
         ecb_cache_path = self.config_paths.get("ecb_cache")
@@ -40,14 +47,6 @@ class FifoTestCaseBase:
             os.remove(classification_cache_path)
         if ecb_cache_path and os.path.exists(ecb_cache_path):
             os.remove(ecb_cache_path)
-        
-        # Store original tax year to reset it later if patched globally
-        try:
-            from src import config as app_config
-            self.original_tax_year = app_config.TAX_YEAR
-        except ImportError:
-            self.original_tax_year = 2023 # Fallback
-            print("Warning: src.config not found in FifoTestCaseBase setup, using fallback tax year for original_tax_year.")
 
 
     def _run_pipeline(self,
@@ -67,31 +66,10 @@ class FifoTestCaseBase:
         paths = self.config_paths 
 
         if monkeypatch_global_tax_year:
-            try:
-                # Use a fresh MonkeyPatch instance for this specific patching action
-                mp_tax_year = pytest.MonkeyPatch()
-                # Ensure src.config is the target for patching TAX_YEAR
-                # This assumes src.config can be imported and patched.
-                import src.config as app_config_module_for_tax_year
-                mp_tax_year.setattr(app_config_module_for_tax_year, "TAX_YEAR", tax_year, raising=True)
-                # Store the monkeypatch instance if you need to undo it specifically, 
-                # or rely on pytest's fixture teardown for patches applied via fixtures.
-                # For locally created MonkeyPatch, it's good practice to undo if not auto-managed.
-                request = getattr(self, 'request', None) # If pytest request object is available
-                if request:
-                    request.addfinalizer(mp_tax_year.undo)
-                else: # If used outside a test function context where request fixture is auto-used.
-                    # This scenario is less common for _run_pipeline which is called within tests.
-                    # If self.request is not available, manual undo might be needed or rely on test isolation.
-                    # For safety, we can store it and undo in a finalizer added to the class or test.
-                    # However, monkeypatch applied in a fixture (`mock_config_paths`) is auto-undone.
-                    # Here, TAX_YEAR is patched *conditionally* inside a helper method.
-                    # The fixture _reset_global_tax_year_after_test handles resetting TAX_YEAR.
-                    pass
-
-            except Exception as e:
-                print(f"Warning: Could not monkeypatch src.config.TAX_YEAR to {tax_year}: {e}")
-
+            # Patch via the per-test monkeypatch fixture: pytest reverts it when THIS test
+            # ends, so the patched year cannot leak into later tests or other modules.
+            import src.config as app_config_module_for_tax_year
+            self._monkeypatch.setattr(app_config_module_for_tax_year, "TAX_YEAR", tax_year, raising=True)
 
         file_map = {
             paths["trades"]: (trades_data, create_trades_csv_string),
@@ -113,19 +91,9 @@ class FifoTestCaseBase:
                     f.write(creator_func([])) # Write empty CSV (headers only)
         
         try:
-            # Ensure IS_INTERACTIVE_CLASSIFICATION is False for tests
-            mp_interactive = pytest.MonkeyPatch()
-            try:
-                import src.config as app_config_module_interactive
-                mp_interactive.setattr(app_config_module_interactive, "IS_INTERACTIVE_CLASSIFICATION", False)
-                # If using request fixture, it would handle undo:
-                # request = getattr(self, 'request', None)
-                # if request: request.addfinalizer(mp_interactive.undo)
-            except ImportError:
-                print("Warning: Could not import src.config to set IS_INTERACTIVE_CLASSIFICATION for test.")
-            except AttributeError:
-                 print(f"Warning: Could not set IS_INTERACTIVE_CLASSIFICATION on src.config module.")
-
+            # Ensure IS_INTERACTIVE_CLASSIFICATION is False for tests (auto-undone at teardown)
+            import src.config as app_config_module_interactive
+            self._monkeypatch.setattr(app_config_module_interactive, "IS_INTERACTIVE_CLASSIFICATION", False)
 
             results: ProcessingOutput = run_core_processing_pipeline(
                 trades_file_path=paths["trades"],
@@ -138,7 +106,6 @@ class FifoTestCaseBase:
                 custom_rate_provider=custom_rate_provider,
                 cash_balance_file_path=paths["cash_balance"]
             )
-            mp_interactive.undo() # Manually undo if not tied to fixture lifecycle
             return results
 
         except Exception as e:
@@ -233,38 +200,3 @@ class FifoTestCaseBase:
                  f"not found or did not match in actual EOY asset states. "
                  f"Checked against {len(all_actual_assets)} assets with details: {[(a.internal_asset_id, a.get_classification_key() if hasattr(a, 'get_classification_key') else 'N/A', a.eoy_quantity) for a in all_actual_assets]}.")
 
-    @pytest.fixture(autouse=True)
-    def _reset_global_tax_year_after_test(self, request):
-        """Resets the global TAX_YEAR in src.config after each test method if it was patched."""
-        # This fixture uses 'request' to manage teardown, ensuring patches are undone.
-        # It stores the original tax year before any test-specific patches in _run_pipeline.
-        # It must run after setup_test_paths_and_config which might set self.original_tax_year.
-        
-        # If _run_pipeline conditionally patches TAX_YEAR, that patch should ideally also be
-        # added to pytest's finalizer chain to ensure it's undone.
-        # The current _run_pipeline tries to use a local monkeypatch or rely on this fixture.
-        
-        # Store original tax year at the beginning of the test method's lifecycle
-        # Note: self.original_tax_year is already set by setup_test_paths_and_config
-        original_year_for_this_test = getattr(self, 'original_tax_year', 2023) # Default if not set
-
-        yield # Test runs here
-
-        # Teardown: Reset TAX_YEAR to its original value for this test instance
-        # This ensures that if _run_pipeline changed it, it's restored.
-        try:
-            mp_teardown = pytest.MonkeyPatch() # Use a new instance for teardown
-            # Ensure src.config is the target for patching TAX_YEAR
-            import src.config as app_config_module_teardown
-            current_patched_year = app_config_module_teardown.TAX_YEAR
-            if current_patched_year != original_year_for_this_test:
-                 mp_teardown.setattr(app_config_module_teardown, "TAX_YEAR", original_year_for_this_test, raising=True)
-            # mp_teardown.undo() # MonkeyPatch.undo() for locally created instances is good practice if not fixture-managed
-        except Exception as e:
-            print(f"Warning: Could not reset src.config.TAX_YEAR to {original_year_for_this_test}: {e}")
-        
-        # Clean up monkeypatch instance if stored on self from _run_pipeline (if it was structured to do so)
-        # However, _run_pipeline as provided uses local MonkeyPatch instances or this fixture.
-        if hasattr(self, '_mp_tax_year_instance_from_run_pipeline'): # Example if _run_pipeline stored its patcher
-            self._mp_tax_year_instance_from_run_pipeline.undo()
-            delattr(self, '_mp_tax_year_instance_from_run_pipeline')

--- a/tests/test_group6_loss_offsetting.py
+++ b/tests/test_group6_loss_offsetting.py
@@ -32,6 +32,7 @@ import src.config as global_config
 # Fixtures imports
 from tests.fixtures.loss_offsetting_data import (
     LOSS_OFFSETTING_TESTS,
+    LOSS_OFFSETTING_TESTS_2025,
     LossOffsettingTestCase,
 )
 
@@ -283,7 +284,7 @@ class TestLossOffsettingFromSpec:
             vorabpauschale_items=[],
             current_year_financial_events=mock_current_year_events,
             asset_resolver=asset_resolver,
-            tax_year=global_config.TAX_YEAR,
+            tax_year=2024,  # pinned: the fixtures encode VZ <= 2024 form law (see fixture header)
             apply_conceptual_derivative_loss_capping=global_config.APPLY_CONCEPTUAL_DERIVATIVE_LOSS_CAPPING,
         )
         result: LossOffsettingResult = engine.calculate_reporting_figures()
@@ -332,6 +333,55 @@ class TestLossOffsettingFromSpec:
 
 
 # =============================================================================
+# VZ >= 2025 form law (post-JStG 2024)
+# =============================================================================
+
+class TestLossOffsetting2025FromSpec:
+    """Verify the VZ >= 2025 Anlage KAP structure (JStG 2024): Zeilen 21/24
+    removed, derivative gains AND losses net in Zeile 19, Zeile 22 includes
+    derivative losses, and no €20k cap (capped == uncapped).
+    Legal basis: reference/tax-law/estg-20-abs6-verlustverrechnung.md."""
+
+    @pytest.mark.parametrize(
+        "test_case",
+        LOSS_OFFSETTING_TESTS_2025,
+        ids=[tc.id for tc in LOSS_OFFSETTING_TESTS_2025],
+    )
+    def test_loss_offsetting_scenario_2025(self, test_case: LossOffsettingTestCase):
+        asset_resolver = MockAssetResolver()
+        mock_rgls = build_rgls_from_test_case(test_case, asset_resolver)
+
+        engine = LossOffsettingEngine(
+            realized_gains_losses=mock_rgls,
+            vorabpauschale_items=[],
+            current_year_financial_events=[],
+            asset_resolver=asset_resolver,
+            tax_year=2025,  # pinned: these fixtures encode the post-JStG-2024 form law
+            apply_conceptual_derivative_loss_capping=True,  # must be inert for 2025
+        )
+        result: LossOffsettingResult = engine.calculate_reporting_figures()
+
+        expected = test_case.expected
+        for form_key, engine_key in FORM_LINE_TO_ENGINE_KEY.items():
+            expected_value = getattr(expected, form_key)
+            actual_value = result.form_line_values.get(engine_key, Decimal("0.00"))
+            assert actual_value.compare(expected_value) == Decimal("0"), (
+                f"{test_case.id}: Form line {form_key} mismatch. "
+                f"Expected {expected_value}, got {actual_value}. "
+                f"Inputs: {test_case.inputs}"
+            )
+
+        for concept_key, engine_field in CONCEPTUAL_TO_ENGINE_FIELD.items():
+            expected_value = getattr(expected, concept_key)
+            actual_value = getattr(result, engine_field, Decimal("0.00"))
+            assert actual_value.compare(expected_value) == Decimal("0"), (
+                f"{test_case.id}: Conceptual {concept_key} mismatch. "
+                f"Expected {expected_value}, got {actual_value}. "
+                f"Inputs: {test_case.inputs}"
+            )
+
+
+# =============================================================================
 # Additional Test Categories
 # =============================================================================
 
@@ -354,7 +404,7 @@ class TestLossOffsettingDerivativeCap:
             vorabpauschale_items=[],
             current_year_financial_events=[],
             asset_resolver=asset_resolver,
-            tax_year=global_config.TAX_YEAR,
+            tax_year=2024,  # pinned: the fixtures encode VZ <= 2024 form law (see fixture header)
             apply_conceptual_derivative_loss_capping=True,
         )
         result = engine.calculate_reporting_figures()
@@ -375,7 +425,7 @@ class TestLossOffsettingDerivativeCap:
             vorabpauschale_items=[],
             current_year_financial_events=[],
             asset_resolver=asset_resolver,
-            tax_year=global_config.TAX_YEAR,
+            tax_year=2024,  # pinned: the fixtures encode VZ <= 2024 form law (see fixture header)
             apply_conceptual_derivative_loss_capping=True,
         )
         result = engine.calculate_reporting_figures()
@@ -405,7 +455,7 @@ class TestLossOffsettingFundIsolation:
             vorabpauschale_items=[],
             current_year_financial_events=[],
             asset_resolver=asset_resolver,
-            tax_year=global_config.TAX_YEAR,
+            tax_year=2024,  # pinned: the fixtures encode VZ <= 2024 form law (see fixture header)
             apply_conceptual_derivative_loss_capping=True,
         )
         result = engine.calculate_reporting_figures()
@@ -432,7 +482,7 @@ class TestLossOffsettingFundIsolation:
             vorabpauschale_items=[],
             current_year_financial_events=[],
             asset_resolver=asset_resolver,
-            tax_year=global_config.TAX_YEAR,
+            tax_year=2024,  # pinned: the fixtures encode VZ <= 2024 form law (see fixture header)
             apply_conceptual_derivative_loss_capping=True,
         )
         result = engine.calculate_reporting_figures()


### PR DESCRIPTION
Part of uebber#15          Standalone: yes
Issue: the suite's results depended on test execution order — group-6 loss-offsetting tests inherited whatever `TAX_YEAR` a previously-run test had leaked, so a green run did not prove the law year it claimed to test.
Legal basis: §20 Abs. 6 EStG year rules (reference/tax-law/estg-20-abs6-verlustverrechnung.md)
Contains: tests only — group 6 pinned to its law year, leak tripwire in conftest, 2025-law scenarios added. (Also carries the package's plan document.)
Merge notes: first in the train; hardens trust in every green run that follows.
