### PR TITLE
tests: replace four tests that asserted nothing, and cover a declared figure that had none

### DIFF
--- a/docs/legal-implementation-map.md
+++ b/docs/legal-implementation-map.md
@@ -357,7 +357,7 @@ To fix, three things are needed together:
 
 | Claim | Position | Module | Guarding tests | Notes |
 |---|---|---|---|---|
-| GT-FX-001 | implements | `FX_CONVERSION_SALE`, `FX_CONVERSION_SHORT_COVER`, `FX_IMPLICIT_SECURITY_PURCHASE`, `FX_IMPLICIT_SECURITY_SALE`, `FX_IMPLICIT_CASHFLOW_EXPENSE`, `FX_IMPLICIT_CASHFLOW_INCOME` → `ANLAGE_KAP_SONSTIGE_KAPITALERTRAEGE` / `_VERLUSTE` | `test_group7_currency_fifo.py`, `test_group9_variable_fx.py`, `test_group11_cashflow_currency.py`, `test_fx_rgl_hardening.py` | All currency balances are treated as § 20; see Q7. |
+| GT-FX-001 | implements | `FX_CONVERSION_SALE`, `FX_CONVERSION_SHORT_COVER`, `FX_IMPLICIT_SECURITY_PURCHASE`, `FX_IMPLICIT_SECURITY_SALE`, `FX_IMPLICIT_CASHFLOW_EXPENSE`, `FX_IMPLICIT_CASHFLOW_INCOME` → `ANLAGE_KAP_SONSTIGE_KAPITALERTRAEGE` / `_VERLUSTE` | `test_group7_currency_fifo.py`, `test_group9_variable_fx.py`, `test_group11_cashflow_currency.py`, `test_fx_rgl_hardening.py` | All currency balances are treated as § 20; see Q7. **The cash-flow debit case (`FX_IMPLICIT_CASHFLOW_EXPENSE`/`_INCOME`) is an extension of this claim, not one of the disposing events Rz. 131 enumerates — see Q10.** |
 | GT-FX-002 | not reached | — | — | Non-interest-bearing accounts. A margin brokerage account pays or charges interest on balances, so the § 23 branch is not exercised — **but nothing tests the account's actual character.** |
 | GT-FX-003 | not reached | — | — | Pure payment accounts. |
 | GT-FX-004 | not reached | — | — | Retroactivity to VZ 2009 and the 2025 bank withholding duty both concern German Zahlstellen. |

--- a/reference/bmf-guidance/fremdwaehrung-konten.md
+++ b/reference/bmf-guidance/fremdwaehrung-konten.md
@@ -104,6 +104,12 @@ Consequences, all carried by Rz. 131 above:
 - **Every Einzahlung and every Zinsgutschrift is an Anschaffungsvorgang.** A repayment is a
   veraeusserungsgleicher Vorgang under Abs. 2 Satz 2 -- and it is one whether or not the amount is
   converted into EUR or a third currency at the same time.
+
+**Not decided by Rz. 131: a balance debited to settle a cash-flow item** -- a withholding tax, a
+fee, a charge paid out of the balance rather than converted. Rz. 131 opens on *Veraeusserung oder
+Rueckzahlung* and then names specific cases; a payment out of the balance is not among them, and
+no Tier 1 or Tier 2 source deciding it has been located. Registered in
+`../research/open-legal-questions.md` Q10.
 - **Re-investment and transfer are disposals too.** Placing a matured balance on deposit again, or
   moving it to another interest-bearing account at the same or a different institution, is a
   disposal of the old Kapitalforderung and an acquisition of a new one.

--- a/reference/research/coverage-matrix.md
+++ b/reference/research/coverage-matrix.md
@@ -50,6 +50,7 @@ have is worse than one with a visible hole.
 | VP deduction on sale | InvStG | 19 Abs. 1 S. 3-4 | KAP-INV **Z53** (not Z55) | invstg-19-veraeusserungsgewinne.md |
 | FX gain (explicit conversion) | EStG | 20 Abs. 2 S. 1 Nr. 7 i.V.m. S. 2 (verzinslich) / 23 Abs. 1 S. 1 Nr. 2 (unverzinslich) | KAP Z19/22 or SO | fremdwaehrung-konten.md |
 | FX gain (currency leg of a securities trade) | -- | **unresolved**; Rz. 131 does *not* address it | KAP Z19/22 | fremdwaehrung-konten.md [GT-FX-007], open-legal-questions.md Q9 |
+| FX gain (currency consumed to settle a cash-flow item) | -- | **unresolved**; Rz. 131 names Veraeusserung and Rueckzahlung, not a payment out of the balance | KAP Z19/22 | fremdwaehrung-konten.md [GT-FX-001], open-legal-questions.md Q10 |
 | Private sale (Gold ETC etc.) | EStG | 23 Abs. 1 S. 1 Nr. 2 S. 1 | SO Z54 | estg-23-private-veraeusserung.md |
 | Jahresfrist arithmetic | AO / BGB | 108 Abs. 1 AO, 187 Abs. 1 / 188 Abs. 2-3 BGB | (decides SO Z54 vs. exempt) | estg-23-private-veraeusserung.md |
 | Jahresfrist, currency lot order | EStG | 23 Abs. 1 S. 1 Nr. 2 S. 3 | (decides which acquisition date is compared) | estg-23-private-veraeusserung.md |

--- a/reference/research/open-legal-questions.md
+++ b/reference/research/open-legal-questions.md
@@ -21,6 +21,7 @@ An unresolved question recorded is ground truth. An unresolved question silently
 | Q7 | [GT-FX-005] | Are currency gains on an interest-bearing account really § 20 EStG income, or do they remain within § 23 Abs. 1 Satz 1 Nr. 2? | `../bmf-guidance/fremdwaehrung-konten.md` |
 | Q8 | [GT-FX-006] | How is a short (negative) currency position taxed in Privatvermoegen? | `../bmf-guidance/fremdwaehrung-konten.md` |
 | Q9 | [GT-FX-007] | Is the currency leg embedded in a foreign securities transaction a separate disposal? | `../bmf-guidance/fremdwaehrung-konten.md` |
+| Q10 | [GT-FX-001] | Is a foreign-currency balance debited to settle a cash-flow item disposed of, measured separately in EUR? | this file |
 
 **Closed 2026-08-03, and recorded here so it is not reopened by habit:** lot identification for
 foreign-currency amounts. It is FIFO under both classifications -- § 23 Abs. 1 Satz 1 Nr. 2 Satz 3
@@ -171,6 +172,33 @@ A related point that is **no longer open**: lot identification for currency. It 
 classifications -- Rz. 131 for the § 20 branch, § 23 Abs. 1 Satz 1 Nr. 2 Satz 3 for the § 23
 branch. The library previously grounded it in § 20 Abs. 4 Satz 7, which cannot reach a currency
 balance.
+
+## Q10 -- currency consumed to settle a cash-flow item
+
+A foreign-currency balance is debited to pay withholding tax, a fee, or a similar item. Is that
+debit a disposal of the currency, measured separately in EUR against the acquisition cost of the
+amount consumed?
+
+**Reading A (a separately measured disposal).** Rz. 131 states the trigger generally before it
+names cases: *"Waehrungsgewinne/-verluste aus der **Veraeusserung oder Rueckzahlung** einer ...
+verzinslichen Kapitalforderung oder eines verzinslichen Fremdwaehrungsguthabens ... sind gemaess
+§ 20 Absatz 2 Satz 1 Nummer 7 und Absatz 4 Satz 1 EStG zu beruecksichtigen."* A payment made out of
+the balance extinguishes part of the Kapitalforderung and so realises the difference between its
+EUR value at acquisition and at extinction, on the same footing as the cases the Randziffer then
+lists. Reading it otherwise lets a currency gain escape measurement whenever the balance is spent
+rather than converted back.
+
+**Reading B (not a separate disposal).** Rz. 131's enumeration is of Rueckzahlung, re-investment
+and transfer to another interest-bearing account. A payment made out of the balance is not among
+them, and the item being settled is itself the taxable event, measured at the rate of its own day.
+On this reading the currency movement is a means of settlement, not a second transaction.
+
+No Tier 1 or Tier 2 statement directly on the point has been located. BMF 14.05.2025 was retrieved
+and Rz. 131 read in full on 2026-08-03; it does not reach the question either way. This is a
+narrower point than Q9, which concerns the currency leg of a securities transaction, and the
+correction recorded there -- that Rz. 131 does not carry separate measurement -- applies here with
+equal force. The choice is not neutral in amount: Reading A produces a gain or loss line that
+Reading B does not.
 
 ---
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -571,6 +571,9 @@ class CurrencyFifoTestSpec:
     has_explicit_rgl_expectations: bool = True
     # Whether the pipeline is expected to raise an error (e.g., DataIntegrityError)
     expect_pipeline_error: bool = False
+    # Substring the raised error must carry. Without it a spec only pins THAT the
+    # pipeline failed, not that it failed for the reason the spec is about.
+    expect_pipeline_error_match: Optional[str] = None
     # Skip flag for tests that test unimplemented features
     skip: bool = False
     skip_reason: Optional[str] = None
@@ -853,6 +856,7 @@ def parse_currency_fifo_tests(spec_data: Dict[str, Any]) -> List[CurrencyFifoTes
             has_explicit_rgl_expectations=has_explicit_rgl_expectations,
             notes=test_dict.get("notes"),
             expect_pipeline_error=test_dict.get("expect_pipeline_error", False),
+            expect_pipeline_error_match=test_dict.get("expect_pipeline_error_match"),
             skip=test_dict.get("skip", False),
             skip_reason=test_dict.get("skip_reason"),
         ))

--- a/tests/fixtures/group7_currency_fifo.yaml
+++ b/tests/fixtures/group7_currency_fifo.yaml
@@ -2601,6 +2601,7 @@ tests:
       The parser raises DataIntegrityError because a zero rate indicates
       corrupt input data that cannot be processed for tax reporting.
     expect_pipeline_error: true
+    expect_pipeline_error_match: "Reported rate is 0, and could not calculate a valid rate"
     inputs:
       currency: XYZ  # Exotic currency with no rate
       soy_balance: "1000.00"
@@ -2618,13 +2619,24 @@ tests:
       errors: 0
 
   - id: CFX_ERR_002
-    description: "Negative quantity in FX trade - error handling"
+    description: "Zero-quantity FX trade row - rejected fail-fast (DataIntegrityError)"
     notes: |
-      Bug Detection: Verify system rejects invalid negative quantities.
+      Bug Detection: a degenerate FX row with zero amounts must reach the
+      ENGINE (not be filtered by test plumbing). The factory rejects it
+      fail-fast with DataIntegrityError ("zero quantity. Cannot determine
+      direction/amounts") - corrupt input must never be silently dropped from
+      a tax computation.
 
-      When from_amount is negative, the trade is invalid and should be
-      skipped during CSV row creation. No FIFO lot is consumed, no RGL
-      is generated, and the SOY balance remains unchanged.
+      (The previous version of this spec used a negative from_amount that the
+      test-support row builder silently dropped before the engine ever saw it
+      - it tested nothing from the day it was written (bdd9688, 2026-03-08).
+      Negative amounts in specs now raise at row-creation
+      time: real IBKR FX-pair rows encode direction in the sign of the EUR-leg
+      quantity, so spec amounts are absolute by definition.)
+    expect_pipeline_error: true
+    expect_pipeline_error_match: "zero quantity\\. Cannot determine direction/amounts"
+    # Inert under expect_pipeline_error: the runner asserts the raise and returns
+    # before reading rgls / errors / eoy_balance_expected. Kept for shape only.
     inputs:
       currency: USD
       soy_balance: "1000.00"
@@ -2632,14 +2644,14 @@ tests:
         - type: SELL_FOREIGN
           date: "2023-06-01"
           from_currency: USD
-          from_amount: "-500.00"  # Invalid negative - trade will be skipped
+          from_amount: "0.00"   # degenerate zero-quantity row, reaches the engine
           to_currency: EUR
-          to_amount: "450.00"
+          to_amount: "0.00"
           ecb_rate: "1.11"
-      eoy_balance_expected: "1000.00"  # Unchanged - invalid trade skipped
+      eoy_balance_expected: "1000.00"
     expected:
-      rgls: []  # No RGL - invalid trade skipped
-      errors: 0  # No EOY mismatch
+      rgls: []
+      errors: 0
 
   - id: CFX_ERR_003
     description: "Consume from empty lot - short position handling"

--- a/tests/test_fx_rgl_hardening.py
+++ b/tests/test_fx_rgl_hardening.py
@@ -165,34 +165,60 @@ class TestIssueA_SoyRateFallback:
 # =============================================================================
 
 class TestIssueD_SignConventionGuard:
-    """domain_event_factory raises ValueError for negative gross_amount_foreign_currency."""
+    """Sign convention: gross_amount_foreign_currency on a TradeEvent is ALWAYS
+    non-negative — direction is encoded in event_type. The factory normalizes the
+    sign with copy_abs(), so a SELL row's negative qty*price becomes a positive
+    gross.
 
-    def test_trade_event_rejects_negative_gross_amount(self):
-        """TradeEvent creation via factory must reject negative gross amounts."""
+    The `raise ValueError` below that construction is unreachable: copy_abs() on
+    the preceding line makes its condition unsatisfiable, and deleting the whole
+    block leaves the suite green. It is not exercised here because it cannot be.
+    Removing it would be an application-code change and is raised for the
+    maintainer rather than made here."""
+
+    def test_factory_normalizes_sell_row_to_positive_gross(self):
+        """A SELL trade row must yield a TradeEvent whose direction lives in
+        event_type, whose quantity stays signed, and whose gross is POSITIVE —
+        exercised through the real parse_trades_csv → DomainEventFactory path.
+
+        legal_basis: infrastructure. No declared figure depends on this test:
+        it pins an internal sign convention, not a tax outcome.
+
+        Scope, measured rather than assumed: the abs is applied twice on this
+        path (once when gross is derived from |qty| * price, once again at
+        construction). Removing either alone changes nothing, and removing both
+        fails a large part of the suite. So this test adds no detection the suite
+        lacks; what it adds is fidelity — the previous version constructed a
+        TradeEvent by hand and asserted the value it had just passed in,
+        exercising no part of the factory."""
+        from src.parsers.trades_parser import parse_trades_csv
+        from src.parsers.domain_event_factory import DomainEventFactory
+        from src.identification.asset_resolver import AssetResolver
+        from src.classification.asset_classifier import AssetClassifier
         from src.domain.events import TradeEvent
+        from tests.support.csv_creators import create_trades_csv_string
+        import tempfile, os
 
-        # Direct construction with negative gross — the guard is in the factory,
-        # not the dataclass, so we test the factory path.
-        # But we can also test that the factory guard works by importing it.
-        # For a unit test, verify the dataclass allows it (no guard there)
-        # and the factory rejects it.
-        # The assertion is in domain_event_factory.py after TradeEvent construction.
-        # We test it indirectly by checking the factory raises.
+        sell_row = [
+            "U_TEST", "USD", "STK", "COMMON", "ABC", "ABC Inc", "US000000ABC1",
+            "", "", "", "20230615", "-100", "50.00", "1.00", "USD",
+            "SELL", "T_SELL_1", "", "", "CONABC", "", "1", "C",
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "trades.csv")
+            with open(path, "w", encoding="utf-8-sig") as fh:
+                fh.write(create_trades_csv_string([sell_row]))
+            raw = parse_trades_csv(path)
+            resolver = AssetResolver(asset_classifier=AssetClassifier(
+                cache_file_path=os.path.join(tmp, "cls.json")))
+            events, _candidates, _stock = DomainEventFactory(resolver).create_events_from_trades(raw)
 
-        # For a direct unit test of the guard logic:
-        trade_event = TradeEvent(
-            asset_internal_id=uuid.uuid4(),
-            event_date="2023-06-15",
-            event_type=FinancialEventType.TRADE_BUY_LONG,
-            quantity=Decimal("100"),
-            price_foreign_currency=Decimal("50.00"),
-            commission_foreign_currency=Decimal("1.00"),
-            commission_currency="USD",
-            local_currency="USD",
-            gross_amount_foreign_currency=Decimal("5000"),  # positive — OK
-            ibkr_transaction_id="T001",
-        )
-        assert trade_event.gross_amount_foreign_currency == Decimal("5000")
+        trades = [e for e in events if isinstance(e, TradeEvent)]
+        assert len(trades) == 1
+        ev = trades[0]
+        assert ev.event_type == FinancialEventType.TRADE_SELL_LONG  # direction lives here
+        assert ev.quantity < Decimal("0")                            # signed quantity kept
+        assert ev.gross_amount_foreign_currency == Decimal("5000.00")  # |qty| * price, POSITIVE
 
     def test_historical_replay_warns_on_negative_foreign_amount(self, caplog):
         """Historical replay logs warning for negative gross_amount_foreign_currency."""

--- a/tests/test_group11_cashflow_currency.py
+++ b/tests/test_group11_cashflow_currency.py
@@ -5,9 +5,17 @@ Tests that cash flow events (dividends, interest, withholding tax, fees)
 in foreign currency correctly create/consume currency FIFO lots and
 generate FX gains/losses.
 
-Tax Law Basis:
-- BMF Circular May 2022, Para. 131: IBKR FX reserves are interest-bearing
-- FX gains/losses from cash flows → §20 EStG → Anlage KAP Zeile 19
+legal_basis: GT-FX-001 — a currency balance is an asset under § 20 and its
+disposal is measured in EUR. Lot order is GT-FX-008. The § 20 classification
+itself rests on GT-FX-005, a choice under uncertainty recorded in
+`reference/research/open-legal-questions.md` (Q7).
+
+That a *cash-flow debit* (WHT, fee) is itself a separately measured disposal is
+the engine's recorded position — `docs/legal-implementation-map.md`, GT-FX-001,
+`FX_IMPLICIT_CASHFLOW_EXPENSE`/`_INCOME` — not something the store states. Rz. 131
+enumerates Rückzahlung, re-investment and transfer; the coverage matrix has no row
+for a cash-flow debit. These tests pin the engine's behaviour, and are worded to
+claim no more than that.
 
 Test Organization:
 - CFX_CF_DIV_*  : Dividend income creating currency lots
@@ -471,18 +479,18 @@ class TestCashflowMixedScenarios(FifoTestCaseBase):
             if rgl.asset_category_at_realization == AssetCategory.CASH_BALANCE
         ]
 
-        # WHT on same day as dividend → same rate → FX gain/loss = 0
+        # WHT on same day as dividend → same rate → zero FX gain/loss. Pin ONE
+        # outcome: the RGL must exist (the engine treats the WHT consuming 30 USD
+        # from the dividend lot as a disposal — its recorded position, see the
+        # module docstring) and its gain must be exactly 0.00. The previous
+        # accept-0-or-1 assertion could not catch a dropped-RGL regression.
         from src import config as app_config
-        if len(currency_rgls) == 1:
-            rgl = currency_rgls[0]
-            assert rgl.quantity_realized == Decimal("30")
-            assert rgl.gross_gain_loss_eur.quantize(app_config.OUTPUT_PRECISION_AMOUNTS) == Decimal("0.00")
-            assert rgl.realization_type == RealizationType.FX_IMPLICIT_CASHFLOW_EXPENSE
-        elif len(currency_rgls) == 0:
-            # Zero gain/loss might be filtered - acceptable
-            pass
-        else:
-            pytest.fail(f"Expected 0-1 currency RGLs, got {len(currency_rgls)}: {currency_rgls}")
+        assert len(currency_rgls) == 1, \
+            f"Expected exactly 1 currency RGL (zero-gain disposal), got {len(currency_rgls)}: {currency_rgls}"
+        rgl = currency_rgls[0]
+        assert rgl.quantity_realized == Decimal("30")
+        assert rgl.gross_gain_loss_eur.quantize(app_config.OUTPUT_PRECISION_AMOUNTS) == Decimal("0.00")
+        assert rgl.realization_type == RealizationType.FX_IMPLICIT_CASHFLOW_EXPENSE
 
     def test_soy_lot_then_wht_with_fx_gain(self, mock_config_paths):
         """

--- a/tests/test_group7_currency_fifo.py
+++ b/tests/test_group7_currency_fifo.py
@@ -19,18 +19,23 @@ Related: GT-FX-006 (short currency positions) and GT-FX-007 (currency embedded
 in a securities trade), both choices under uncertainty — see
 reference/research/open-legal-questions.md and docs/legal-implementation-map.md.
 
-Note the store records that the controlling BMF circular has never been
-retrieved and that its Randziffer numbering is ambiguous across versions, so
-these expectations rest on administrative practice, not on a verified Tier 2
-citation.
+The controlling text is the BMF-Schreiben vom 14.05.2025, retrieved and read in
+full on 2026-08-03 and reproduced verbatim in the store. Cite that date with the
+Randziffer: the 14.05.2025 text is a Neufassung of BMF 19.05.2022, and whether
+the older text numbered it identically is not established.
+
+Which expectations in this file that actually grounds: the § 20 classification of
+a currency balance and the FIFO lot order are verified Tier 2 (Rz. 131, GT-FX-008).
+The short-position specs (CFX_S_*, CFX_IS_*) are NOT — Rz. 131 addresses Guthaben
+throughout and says nothing about a negative balance, so they rest on GT-FX-006,
+a choice under uncertainty (Q8). The embedded currency leg of a securities trade
+is GT-FX-007, recorded as reasoned rather than sourced (Q9).
 """
 
-import logging
 import pytest
 from decimal import Decimal
 from typing import List, Tuple, Any, Optional
 
-logger = logging.getLogger(__name__)
 
 from tests.support.base import FifoTestCaseBase
 from tests.support.mock_providers import MockECBExchangeRateProvider
@@ -117,7 +122,7 @@ def create_fx_trade_csv_row(
     trade_date: str,
     transaction_id: str,
     trade_time: Optional[str] = None,
-) -> Optional[List[Any]]:
+) -> List[Any]:
     """
     Create a CSV row for an FX trade.
 
@@ -129,13 +134,14 @@ def create_fx_trade_csv_row(
       - Negative = sell EUR (buy foreign)
     - TradePrice: Exchange rate (foreign per EUR)
     """
-    # Validate inputs - skip trades with invalid amounts or missing rates
+    # Negative amounts are a SPEC-AUTHORING error, not a real IBKR data shape:
+    # IBKR FX-pair rows encode direction in the SIGN of the EUR-leg quantity,
+    # amounts in specs are absolute. Fail loudly instead of silently dropping
+    # the row (a silent skip made CFX_ERR_002 test nothing since it was written (bdd9688, 2026-03-08)).
     if foreign_amount is not None and foreign_amount < Decimal("0"):
-        logger.warning(f"FX trade {transaction_id}: Skipping - negative foreign_amount {foreign_amount}")
-        return None
+        raise ValueError(f"FX trade {transaction_id}: negative foreign_amount {foreign_amount} in spec")
     if eur_amount is not None and eur_amount < Decimal("0"):
-        logger.warning(f"FX trade {transaction_id}: Skipping - negative eur_amount {eur_amount}")
-        return None
+        raise ValueError(f"FX trade {transaction_id}: negative eur_amount {eur_amount} in spec")
 
     symbol = f"EUR.{foreign_currency}"
 
@@ -373,8 +379,7 @@ def spec_to_trades_data(
                 transaction_id=f"FX_T_{i:04d}",
                 trade_time=fx_trade.time,
             )
-            if csv_row is not None:
-                trades_data.append(csv_row)
+            trades_data.append(csv_row)
 
     # Add security trades (for implicit FX)
     for i, sec_trade in enumerate(spec.security_trades):
@@ -866,7 +871,10 @@ class TestCurrencyFifoRGLs(FifoTestCaseBase):
 
         # Tests that expect a pipeline error (e.g., DataIntegrityError for corrupt data)
         if spec.expect_pipeline_error:
-            with pytest.raises(pytest.fail.Exception, match="data integrity"):
+            # "data integrity" only pins THAT the pipeline refused. A spec that
+            # names the condition it is about pins WHY, via expect_pipeline_error_match.
+            expected_match = spec.expect_pipeline_error_match or "data integrity"
+            with pytest.raises(pytest.fail.Exception, match=expected_match):
                 self._run_pipeline(
                     trades_data=trades_data,
                     positions_start_data=positions_start,
@@ -982,6 +990,37 @@ class TestCurrencyFifoAggregates(FifoTestCaseBase):
 # =============================================================================
 # Spec Loading Verification
 # =============================================================================
+
+class TestSpecRowBuilderRejectsNegativeAmounts:
+    """The row builder raises on a negative spec amount instead of dropping the row.
+
+    legal_basis: infrastructure. No declared figure depends on this test — but the
+    behaviour it pins is why other tests in this file can be trusted. The builder
+    used to log and return None, so a spec authored with a negative amount produced
+    no CSV row at all and its expectations were satisfied by the engine never
+    running. CFX_ERR_002 sat in that state and asserted nothing.
+
+    Real IBKR FX-pair rows encode direction in the sign of the EUR-leg quantity, so
+    an amount in a spec is absolute by definition and a negative one is an authoring
+    error, not an input shape to model.
+    """
+
+    def test_negative_foreign_amount_raises(self):
+        with pytest.raises(ValueError, match="negative foreign_amount"):
+            create_fx_trade_csv_row(
+                account_id="U_TEST", foreign_currency="USD", trade_type="SELL_FOREIGN",
+                foreign_amount=Decimal("-500.00"), eur_amount=Decimal("450.00"),
+                ecb_rate=Decimal("1.11"), trade_date="2023-06-01", transaction_id="FX_NEG_1",
+            )
+
+    def test_negative_eur_amount_raises(self):
+        with pytest.raises(ValueError, match="negative eur_amount"):
+            create_fx_trade_csv_row(
+                account_id="U_TEST", foreign_currency="USD", trade_type="SELL_FOREIGN",
+                foreign_amount=Decimal("500.00"), eur_amount=Decimal("-450.00"),
+                ecb_rate=Decimal("1.11"), trade_date="2023-06-01", transaction_id="FX_NEG_2",
+            )
+
 
 class TestCurrencyFifoSpecsLoaded:
     """Verify that currency FIFO specs are loaded correctly."""

--- a/tests/test_withholding_tax_linker.py
+++ b/tests/test_withholding_tax_linker.py
@@ -219,25 +219,125 @@ class TestWithholdingTaxLinker:
         assert len(links) == 0
         assert len(unlinked) == 1
     
-    def test_multiple_wht_events_best_match(self):
-        """Test that the best matching WHT event is selected when multiple candidates exist."""
-        dividend_event = self.create_dividend_event()
-        
-        # Create two WHT events, one with sequential ID (better match)
-        wht_event_1 = self.create_withholding_tax_event(transaction_id="1633925901")  # Sequential
-        wht_event_2 = self.create_withholding_tax_event(transaction_id="9999999")    # Non-sequential
-        
-        events = [dividend_event, wht_event_1, wht_event_2]
+    def test_two_dividends_each_wht_pairs_with_its_own(self):
+        """Realistic multi-candidate case: TWO dividends, TWO WHT events — each
+        WHT must link to ITS OWN dividend (sequential transaction ids decide).
+
+        legal_basis: GT-FORM-006 / GT-CREDIT-004 — withholding events are summed
+        into ANLAGE_KAP_FOREIGN_TAX_PAID. Note what that means for this test:
+        `loss_offsetting.py` sums `WithholdingTaxEvent.gross_amount_eur` over
+        events and never consults the links, so a wrong link cannot by itself
+        move Zeile 41. What the attribution decides is which income event a
+        credit is reported against, and the previous version of this test used
+        one dividend and blessed BOTH WHT events linking to it — leaving the
+        attribution rule untested rather than leaving a figure wrong."""
+        dividend_a = self.create_dividend_event(amount=Decimal("206.00"), transaction_id="1633925900")
+        dividend_b = self.create_dividend_event(amount=Decimal("100.00"), transaction_id="1633926900")
+        wht_a = self.create_withholding_tax_event(amount=Decimal("30.90"), transaction_id="1633925901")
+        wht_b = self.create_withholding_tax_event(amount=Decimal("15.00"), transaction_id="1633926901")
+
+        events = [dividend_a, dividend_b, wht_a, wht_b]
         links, unlinked = self.linker.link_withholding_tax_events(events)
-        
-        assert len(links) == 2  # Both should be linked to same dividend (in real scenario, you'd have 2 dividends)
-        # But let's test that the sequential one gets higher confidence
-        
-        # Find the link with higher confidence
-        high_confidence_link = max(links, key=lambda x: x.link_confidence_score)
-        assert high_confidence_link.link_confidence_score == 100
-        assert high_confidence_link.withholding_tax_event_id == wht_event_1.event_id
+
+        assert len(links) == 2
+        assert len(unlinked) == 0
+        by_wht = {l.withholding_tax_event_id: l for l in links}
+        assert by_wht[wht_a.event_id].linked_income_event_id == dividend_a.event_id
+        assert by_wht[wht_b.event_id].linked_income_event_id == dividend_b.event_id
+        # Both are exact matches via sequential ids
+        assert by_wht[wht_a.event_id].link_confidence_score == 100
+        assert by_wht[wht_b.event_id].link_confidence_score == 100
+        # No double-link: two distinct income events are referenced
+        assert len({l.linked_income_event_id for l in links}) == 2
     
+    def test_two_wht_events_against_one_dividend(self):
+        """Two withholding entries against a single dividend: the engine links
+        BOTH to that dividend. This pins current behaviour so a change to it is
+        visible.
+
+        legal_basis: infrastructure. No declared figure turns on it — Zeile 41
+        sums the WithholdingTaxEvents themselves and never reads the links
+        (see test_withholding_events_sum_into_zeile_41), and the links are
+        consumed only by the console, PDF and diagnostic reports.
+
+        The previous version of this file asserted the same shape but framed it
+        as picking a "best match"; the point here is narrower and honest — an
+        income event may currently carry more than one link, nothing forbids it,
+        and if that ever becomes one-to-one this test is what says so.
+        """
+        dividend = self.create_dividend_event(transaction_id="1633925900")
+        wht_1 = self.create_withholding_tax_event(transaction_id="1633925901")
+        wht_2 = self.create_withholding_tax_event(transaction_id="9999999")
+
+        links, unlinked = self.linker.link_withholding_tax_events(
+            [dividend, wht_1, wht_2])
+
+        assert len(links) == 2, "both WHT events link; nothing enforces one-to-one"
+        assert len(unlinked) == 0
+        assert {l.linked_income_event_id for l in links} == {dividend.event_id}, \
+            "both links point at the single dividend"
+
+    def test_withholding_events_sum_into_zeile_41(self, tmp_path):
+        """The withholding events themselves — not their links — are what
+        Zeile 41 is built from.
+
+        legal_basis: GT-FORM-006 / GT-CREDIT-004 — Zeile 41 aggregates
+        *foreign* withholding tax into one figure. This is a declared figure and,
+        before this test, nothing in the suite asserted it: replacing the
+        accumulation in `loss_offsetting.py` with `pass` left the whole suite
+        green, while `docs/legal-implementation-map.md` named this file as the
+        guard for both claims.
+
+        What this test does NOT certify, on two counts:
+
+        - The engine sums every withholding event with no country filter, which
+          the map records as the known defect GT-CREDIT-025, and GT-FORM-007
+          states German KESt withheld through a foreign depot does not belong in
+          Zeile 41 at all. The fixture here is a Canadian asset, so the expected
+          value is unaffected either way and this test keeps passing once the
+          filter is added.
+        - GT-CREDIT-005 and GT-CREDIT-006 impose a per-Kapitalertrag and a
+          per-VZ ceiling. The engine applies neither — the map records that the
+          Finanzamt does — and nothing in the store says the taxpayer enters the
+          uncapped figure. This fixture carries no Kapitalertrag at all, so the
+          assertion cannot observe either ceiling in any direction.
+
+        The value asserted here is therefore the aggregation rule and nothing
+        beyond it.
+        """
+        from src.engine.loss_offsetting import LossOffsettingEngine
+        from src.domain.enums import TaxReportingCategory
+        from src.identification.asset_resolver import AssetResolver
+        from src.classification.asset_classifier import AssetClassifier
+
+        resolver = AssetResolver(asset_classifier=AssetClassifier(
+            cache_file_path=str(tmp_path / "cls.json")))
+        asset = resolver.get_or_create_asset(
+            raw_isin="CA0641491075", raw_conid="CONBNS", raw_symbol="BNS",
+            raw_currency="CAD", raw_ibkr_asset_class="STK",
+            raw_description="BANK OF NOVA SCOTIA", raw_ibkr_sub_category="COMMON",
+        )
+
+        wht_a = self.create_withholding_tax_event(amount=Decimal("30.90"), transaction_id="1633925901")
+        wht_a.asset_internal_id = asset.internal_asset_id
+        wht_a.gross_amount_eur = Decimal("21.00")
+        wht_b = self.create_withholding_tax_event(amount=Decimal("15.00"), transaction_id="1633926901")
+        wht_b.asset_internal_id = asset.internal_asset_id
+        wht_b.gross_amount_eur = Decimal("10.50")
+
+        engine = LossOffsettingEngine(
+            realized_gains_losses=[],
+            vorabpauschale_items=[],
+            current_year_financial_events=[wht_a, wht_b],
+            asset_resolver=resolver,
+            tax_year=2023,
+        )
+        form = engine.calculate_reporting_figures()
+
+        assert form.form_line_values.get(
+            TaxReportingCategory.ANLAGE_KAP_FOREIGN_TAX_PAID, Decimal("0.00")
+        ) == Decimal("31.50"), "Zeile 41 aggregates the withholding events' EUR amounts (GT-FORM-006)"
+
     def test_is_sequential_transaction_id(self):
         """Test the sequential transaction ID logic."""
         wht_event = self.create_withholding_tax_event(transaction_id="1000002")

--- a/tests/test_withholding_tax_linker.py
+++ b/tests/test_withholding_tax_linker.py
@@ -338,6 +338,59 @@ class TestWithholdingTaxLinker:
             TaxReportingCategory.ANLAGE_KAP_FOREIGN_TAX_PAID, Decimal("0.00")
         ) == Decimal("31.50"), "Zeile 41 aggregates the withholding events' EUR amounts (GT-FORM-006)"
 
+    @pytest.mark.xfail(strict=True, reason="GT-CREDIT-025: no country filter on Zeile 41")
+    def test_german_kest_is_excluded_from_zeile_41(self, tmp_path):
+        """German Kapitalertragsteuer must not be declared as anrechenbare
+        ausländische Steuer.
+
+        legal_basis: GT-FORM-007 — "German Kapitalertragsteuer withheld on a
+        German issuer's dividend is **not** an ausländische Steuer and does not
+        belong in Zeile 41." It is credited through Zeile 7 with Zeilen 37/38/39.
+
+        This is the known defect GT-CREDIT-025, recorded in
+        `docs/legal-implementation-map.md` as prose. It is marked
+        xfail(strict=True) so that it is an instrument rather than a note: it
+        fails today because the sum has no country filter, and the day the filter
+        lands it will XPASS, which strict=True turns into a failure — forcing the
+        marker to be removed rather than leaving a stale xfail behind.
+
+        Note the fix is larger than this assertion: GT-FORM-007 puts the credit
+        on Zeilen 7/37/38/39, which have no representation at all, so excluding
+        the amount here without adding those lines would drop the credit rather
+        than move it. That is why this test states the requirement and does not
+        attempt the fix.
+        """
+        from src.engine.loss_offsetting import LossOffsettingEngine
+        from src.domain.enums import TaxReportingCategory
+        from src.identification.asset_resolver import AssetResolver
+        from src.classification.asset_classifier import AssetClassifier
+
+        resolver = AssetResolver(asset_classifier=AssetClassifier(
+            cache_file_path=str(tmp_path / "cls.json")))
+        german = resolver.get_or_create_asset(
+            raw_isin="DE0007164600", raw_conid="CONSAP", raw_symbol="SAP",
+            raw_currency="EUR", raw_ibkr_asset_class="STK",
+            raw_description="SAP SE", raw_ibkr_sub_category="COMMON",
+        )
+
+        kest = self.create_withholding_tax_event(amount=Decimal("26.375"), currency="EUR")
+        kest.asset_internal_id = german.internal_asset_id
+        kest.source_country_code = "DE"
+        kest.gross_amount_eur = Decimal("26.375")
+
+        engine = LossOffsettingEngine(
+            realized_gains_losses=[],
+            vorabpauschale_items=[],
+            current_year_financial_events=[kest],
+            asset_resolver=resolver,
+            tax_year=2023,
+        )
+        form = engine.calculate_reporting_figures()
+
+        assert form.form_line_values.get(
+            TaxReportingCategory.ANLAGE_KAP_FOREIGN_TAX_PAID, Decimal("0.00")
+        ) == Decimal("0.00"), "German KESt is not an ausländische Steuer (GT-FORM-007)"
+
     def test_is_sequential_transaction_id(self):
         """Test the sequential transaction ID logic."""
         wht_event = self.create_withholding_tax_event(transaction_id="1000002")


### PR DESCRIPTION
### What this is worth

**This PR fixes no defect.** No figure was wrong before it, none is right after it, no production
code is touched. Deferring it costs nothing in correctness.

What it buys is visibility. Zeile 41 — a declared figure — had no test at all: zeroing it left 527
green. Two further unobserved regressions drop items from a declaration silently. And it surfaced
five findings about the store and the map, three in mechanisms added this week — including a map row
naming a guarding test that guarded nothing. Those are below, and are the part worth your time.

---

Four tests were green without observing their stated subject. Each is replaced and calibrated by
mutation. A fifth gap found while calibrating — a declared figure with no test at all — is closed
here too. No production code changes.

### What was wrong, measured

Baseline **527 passed** at `270dca7` on a simulated clean clone
(`rm -rf cache && cp src/config_example.py src/config.py && uv run pytest -q`). Each production
behaviour was deliberately broken and the whole suite re-run on that baseline:

| break applied | suite at base |
|---|---|
| FX zero-quantity data error deleted (silent skip) | 527 passed |
| zero-gain currency RGLs suppressed (both cash-flow sites) | 527 passed |
| every WHT attributed to the first income event | 527 passed |
| Zeile 41 accumulation replaced with `pass` | 527 passed |

Not one of those four behaviours was observed by anything in the repository.
`ANLAGE_KAP_FOREIGN_TAX_PAID` occurred in **no test at all** at `270dca7`, while
`docs/legal-implementation-map.md` named `test_withholding_tax_linker.py` as the guard for
`GT-FORM-006` and `GT-CREDIT-004`.

Stated precisely: the FX one drops a corrupt row out of the computation; the Zeile 41 one silently
zeroes a declared credit figure; the zero-gain RGL one suppresses a disposal carrying zero gain in
this fixture, so what it shows is that the test could not see a dropped disposal at all; the WHT
attribution moves no figure.

### What each replacement now catches

| break applied | this branch |
|---|---|
| FX zero-quantity data error deleted | `CFX_ERR_002` fails |
| FX error reworded, still "data integrity" | `CFX_ERR_002` fails |
| zero-gain currency RGLs suppressed | group11 ordering fails |
| every WHT to the first income event | linker pairing fails |
| linker forced one-to-one | two-WHT test fails |
| Zeile 41 accumulation replaced with `pass` | Zeile 41 test fails |
| spec row builder reverted to `return None` | both guard tests fail |

### The fourth replacement is fidelity, not detection

`test_factory_normalizes_sell_row_to_positive_gross` exercises the real parse → factory path where
its predecessor hand-built a `TradeEvent` and asserted the value it had just passed in. It adds no
detection the suite lacks: the abs is applied twice, neither single-site removal is caught by it or
by anything else, and removing both already fails 86 other tests (87 including this one).

### Coverage recorded, not deleted

Dropping the old multi-candidate test would have removed the only observer of an income event
carrying more than one withholding link. It is kept as its own test: forcing the linker one-to-one
fails it, and without it the suite stays green.

### Verification

- **531 passed, 1 xfailed** on a simulated clean clone (527 at base, plus two spec row-builder
  guards, the Zeile 41 test, and the two-WHT test). The four replacements are 1:1. The one xfail is
  `test_german_kest_is_excluded_from_zeile_41`, added by the optional commit `a729123`; the required
  commit alone is **531 passed, no xfail**.
- Every mutation applied and reverted in a throwaway `git clone --shared`; the primary tree was
  never mutated.
- **Real-data parity: not measured, and no assessment year is claimed.**
  `git diff --stat 270dca7..a729123 -- src/` is empty — no production code path is touched. The
  `reference/` and `docs/` changes are non-behavioural.

### Three questions I could not answer

Each came out of calibrating one of the four original claims. Two are about the store and the
engine, not about this diff, and none is a defect this PR introduces.

**1. Is a currency debit to settle a cash-flow item a separately measured disposal?**
`GT-FX-001` enumerates Rückzahlung, re-investment and transfer; the coverage matrix had no row;
yet the map records the position as "implements". Optional commit `1676e7b` records it as Q10
without deciding it, registered in all four places `GT-FX-007`/Q9 is.

**2. Zeile 41 and the missing country filter (`GT-CREDIT-025`).**
Optional commit `a729123` makes the recorded defect executable as an `xfail(strict=True)`. It does
not fix it: `GT-FORM-007` puts the credit on Zeilen 7/37/38/39, which have no representation at
all, so excluding the amount from Zeile 41 alone would drop the credit rather than move it.

**3. Should the unreachable negative-gross guard stay?** No commit — a question, with a measurement.
The guard in `domain_event_factory.py` cannot fire: `copy_abs()` on the preceding line makes its
condition unsatisfiable. But it is **not inert**. Removing both `copy_abs()` applications:

```
guard present:  87 failed
guard removed:  72 failed
```

Fifteen tests go quietly green on a negative gross without it — 5 in `test_dividend_handling.py`,
4 FIFO-group specs, `test_forward_split_soy_reconciliation.py`, 5 group7 currency specs. So removing
it trades a loud fail-fast for a quieter failure mode. **Our recommendation: keep the guard, and
change `ValueError` to `DataIntegrityError`**, which is what `CLAUDE.md` prescribes for event
creation. We have not made that change — it is application code, and the Ground rules put it with
you.

### Findings about the store and the map, not about this diff

These are the part worth your attention. None is a defect this PR introduces; all were invisible
while the four tests asserted nothing. Three concern mechanisms you added in the last two days.

**1. The map named a guarding test that did not guard.** `docs/legal-implementation-map.md` cites
`test_withholding_tax_linker.py` for `GT-FORM-006` and `GT-CREDIT-004`. That file asserted nothing
about either, and `ANLAGE_KAP_FOREIGN_TAX_PAID` appeared nowhere under `tests/`. The required commit
makes the row true rather than editing it, but the row was false when written. **Worth a sweep of
the other Guarding-tests cells** — nothing enforces that column.

**2. The 2026-08-03 re-audit left one position held silently.** `GT-FX-001`'s extension to a
cash-flow debit is unsourced: Rz. 131 states *Veräußerung oder Rückzahlung* and names cases that do
not include a payment out of the balance, the coverage matrix had no row, and no question was
registered — yet the map records "implements". Optional commit `1676e7b` registers it as Q10 in all
four places `GT-FX-007`/Q9 occupies.

**3. `45abe83` corrected one file and not its sibling.** It removed *"BMF Circular May 2022,
Para. 131"* from `test_group7_currency_fifo.py`; the identical citation survived in
`test_group11_cashflow_currency.py`. Separately, that commit's replacement docstring said the
circular "has never been retrieved" — which `270dca7` then contradicted by retrieving it, leaving a
stale statement one commit later. Both are corrected in the required commit. This is Validation
Protocol item 8 in miniature: the sweep for what cited the old reading missed a file.

**4. `source_country_code` documents one thing and is assigned another.** `src/domain/events.py`
calls it *"ISO country code of the taxing authority"*; `domain_event_factory.py` assigns
`rct.issuer_country_code`, with a hardcoded `"IE"` fallback for cash balances. Issuer and taxing
authority coincide often but not always. This matters directly if a fix for `GT-CREDIT-025` is ever
keyed on country rather than on the 26.375 % arithmetic signature the map suggests.

**5. A silent default on the path this PR reasons about.** `domain_event_factory.py:385` sets
`calculated_gross_amount = Decimal('0.0')` after a warning when price or quantity is missing —
the §4 shape. Pre-existing, untouched here, and flagged so the commit's analysis of that block is
not read as blessing it.

---
