### PR TITLE
fix(vorabpauschale): every fund either loses its §18 figure or takes the PDF down with it

### DIFF
--- a/docs/legal-implementation-map.md
+++ b/docs/legal-implementation-map.md
@@ -152,13 +152,33 @@ forward carry-over), **2024** and **2025**. Only `separate_derivative_lines`,
 
 | Claim | Position | Module | Guarding tests | Notes |
 |---|---|---|---|---|
-| GT-INVSTG-010 | implements | `_calculate_vorabpauschale()` in `src/engine/calculation_engine.py` | `test_vorabpauschale.py::TestVorabpauschaleCalculation` | Sätze 1–3: Basisertrag, the value-gain cap, and the distribution subtraction. |
+| GT-INVSTG-010 | implements | `_calculate_vorabpauschale()` in `src/engine/calculation_engine.py` | `test_vorabpauschale.py::TestVorabpauschaleCalculation`, `test_vorabpauschale_reclassification.py` | Sätze 1–3: Basisertrag, the value-gain cap, and the distribution subtraction. Reached only for some funds until 2026-08-04 — see below. |
 | GT-INVSTG-011 | **deviates** | — | — | **Abs. 2 pro-rata is not implemented.** The engine computes only for units held at the start of the calendar year, so units acquired during the year produce *nothing* where Abs. 2 gives up to eleven twelfths. Understates deemed income in an acquisition year. |
-| GT-INVSTG-012 | implements | `VorabpauschaleData.vorabpauschale_year` and `.declaration_year` | `test_vorabpauschale.py::TestVorabpauschaleDeclarationYear` | The VZ `Y` return carries the Vorabpauschale for calendar `Y-1`. |
+| GT-INVSTG-012 | implements | `VorabpauschaleData.vorabpauschale_year` and `.declaration_year` | `test_vorabpauschale.py::TestVorabpauschaleDeclarationYear`, `test_pdf_vorabpauschale.py` | The VZ `Y` return carries the Vorabpauschale for calendar `Y-1`. All three output surfaces select on `declaration_year`; the PDF read the pre-rename field until 2026-08-04. |
 | GT-INVSTG-013 | implements | `src/tax_law/registry.py` `BASISZINS_PCT` | `test_tax_law_registry.py::TestBasiszinsLookup` | |
-| GT-INVSTG-014 | implements | `Asset.prior_year_*` fields, populated by `src/data_preparation.py` | `test_vorabpauschale.py::TestVorabpauschaleDeclarationYear` | Where the prior year's snapshots are absent and funds are held, the run stops with a `FAIL_FAST` data gap rather than substituting the tax year's own snapshot. |
+| GT-INVSTG-014 | implements | `Asset.prior_year_*` fields, resolved by `src/data_preparation.py` and populated by `ParsingOrchestrator.process_positions()` | `test_vorabpauschale.py::TestVorabpauschaleDeclarationYear`, `test_vorabpauschale_reclassification.py` | Where the prior year's snapshots are absent and funds are held, the run stops with a `FAIL_FAST` data gap rather than substituting the tax year's own snapshot. Where they are present but do not survive classification, the run stops with a `DataIntegrityError` — see below. |
 | GT-INVSTG-015 | implements | gross on Zeilen 9–13 | `test_vorabpauschale.py::TestTeilfreistellungNegativeDistribution` | |
 | GT-INVSTG-016 | **choice under uncertainty** | funds with no end-of-year position are skipped | `test_vorabpauschale.py` | See below. |
+
+**GT-INVSTG-010 and GT-INVSTG-014 — reached only for some funds until 2026-08-04.** A positions
+row is resolved without its `SubCategory`, so the description is the only fund signal that
+survives: an instrument described as an ETF is created as an `InvestmentFund` outright, and any
+other fund is created as a `Stock` and retyped when the user's classification is applied — which
+is after the prior-year snapshot has been read onto it. Retyping copies a hand-listed set of
+fields and the `prior_year_*` fields were not on it, so a retyped fund reached § 18's
+computation with no year-start Rücknahmepreis and was skipped, with nothing recorded. A fund
+created as a fund was unaffected. **On this repository's own data the distinction is not a
+mitigation:** no fund description contains "ETF", so every one was retyped and Zeilen 9–13 were
+empty on every run, whether or not deemed income was due.
+
+Two guards now stand where that failed. The values read are checked against the values the
+engine will see (`ParsingOrchestrator._verify_prior_year_snapshot_survived_classification`,
+`DataIntegrityError`, naming every affected fund); it follows an alias rather than an id, so an
+instrument merged into another after its snapshot was read is followed to the survivor, and it
+reports investment funds only, since nothing else can lose a declared figure this way. And the
+itemisation is exercised with a record present (`test_pdf_vorabpauschale.py`) — the PDF read the
+pre-rename `tax_year` field and would have raised `AttributeError` on the first run that
+produced one.
 
 **GT-INVSTG-010, Satz 4 — partial.** The Rücknahmepreis is the primary measure and a market price
 substitutes only where none was set. The engine uses the broker's position mark price

--- a/src/identification/asset_resolver.py
+++ b/src/identification/asset_resolver.py
@@ -60,6 +60,18 @@ class AssetResolver:
             "soy_quantity": asset.soy_quantity, # Renamed from initial_quantity_soy
             "soy_cost_basis_amount": asset.soy_cost_basis_amount, # Renamed from initial_cost_basis_money_soy
             "soy_cost_basis_currency": asset.soy_cost_basis_currency, # Renamed from initial_cost_basis_currency_soy
+            # The preceding calendar year's snapshot, read by the Vorabpauschale. A positions
+            # row is resolved without its SubCategory, so unless the description says "ETF" the
+            # fund is created as a Stock and becomes an InvestmentFund only when the user's
+            # classification is applied -- which is after this snapshot has been read onto it.
+            # Omitting these here left such a fund with no year-start Ruecknahmepreis, so
+            # 18 Abs. 1 InvStG had nothing to compute from and the figure vanished from
+            # Zeilen 9-13 with nothing recorded.
+            "prior_year_soy_quantity": asset.prior_year_soy_quantity,
+            "prior_year_soy_position_value": asset.prior_year_soy_position_value,
+            "prior_year_soy_mark_price_currency": asset.prior_year_soy_mark_price_currency,
+            "prior_year_eoy_position_value": asset.prior_year_eoy_position_value,
+            "prior_year_eoy_mark_price_currency": asset.prior_year_eoy_mark_price_currency,
             "eoy_quantity": asset.eoy_quantity,
             "eoy_mark_price_currency": asset.eoy_mark_price_currency,
             "eoy_market_price": asset.eoy_market_price, # Renamed from eoy_mark_price

--- a/src/parsers/parsing_orchestrator.py
+++ b/src/parsers/parsing_orchestrator.py
@@ -12,6 +12,7 @@ from src.domain.assets import (
 # FinancialEvent, OptionLifecycleEvent, TradeEvent for type hinting
 from src.domain.events import FinancialEvent, OptionLifecycleEvent, TradeEvent
 from src.domain.enums import FinancialEventType, AssetCategory, InvestmentFundType
+from src.domain.exceptions import DataIntegrityError
 from src.identification.asset_resolver import AssetResolver
 from src.classification.asset_classifier import AssetClassifier
 from src.utils.sorting_utils import get_event_sort_key
@@ -49,6 +50,10 @@ class ParsingOrchestrator:
         # Preceding calendar year's snapshots -- Vorabpauschale only. See Asset.prior_year_*.
         self.raw_positions_prior_start: List[RawPositionRecord] = []
         self.raw_positions_prior_end: List[RawPositionRecord] = []
+        # Which prior-year snapshot fields were read onto which asset, so the pipeline can
+        # verify they are still there once classification has run. See
+        # _verify_prior_year_snapshot_survived_classification.
+        self._prior_year_snapshot_fields: Dict[uuid.UUID, Dict[str, Any]] = {}
         self.raw_corporate_actions: List[RawCorporateActionRecord] = []
         self.raw_cash_balances: List[RawCashBalanceRecord] = []
         self.raw_options_eae: List[RawOptionsEAERecord] = []
@@ -149,11 +154,85 @@ class ParsingOrchestrator:
             asset.prior_year_soy_quantity = safe_decimal(raw_pos.position, default=Decimal(0))
             asset.prior_year_soy_position_value = safe_decimal(raw_pos.position_value)
             asset.prior_year_soy_mark_price_currency = raw_pos.currency_primary
+            self._record_prior_year_snapshot_fields(asset, (
+                "prior_year_soy_quantity", "prior_year_soy_position_value",
+                "prior_year_soy_mark_price_currency",
+            ))
 
         for raw_pos in self.raw_positions_prior_end:
             asset = self._resolve_asset_from_position(raw_pos)
             asset.prior_year_eoy_position_value = safe_decimal(raw_pos.position_value)
             asset.prior_year_eoy_mark_price_currency = raw_pos.currency_primary
+            self._record_prior_year_snapshot_fields(asset, (
+                "prior_year_eoy_position_value", "prior_year_eoy_mark_price_currency",
+            ))
+
+    def _record_prior_year_snapshot_fields(self, asset: Asset, field_names: Tuple[str, ...]) -> None:
+        """Note which prior-year snapshot values this asset now carries.
+
+        An alias is kept alongside the field names because the asset object recorded here need
+        not be the one the engine sees. Two later rows whose identifiers overlap are merged, and
+        the merge deletes the losing asset and repoints its aliases at the winner. Looking the
+        alias up again resolves to whichever asset ends up owning the instrument.
+        """
+        present = {name for name in field_names if getattr(asset, name, None) is not None}
+        if not present:
+            return
+        record = self._prior_year_snapshot_fields.setdefault(
+            asset.internal_asset_id, {"fields": set(), "alias": None})
+        record["fields"].update(present)
+        if record["alias"] is None and asset.aliases:
+            record["alias"] = next(iter(asset.aliases))
+
+    def _verify_prior_year_snapshot_survived_classification(self) -> None:
+        """Every prior-year snapshot value read above must still be on its asset.
+
+        Classification replaces an asset's Python type by building a new object and copying
+        the old one's fields across (`AssetResolver.replace_asset_type`). A field the copy
+        does not list is dropped, and the drop is invisible: the Vorabpauschale then finds no
+        year-start Ruecknahmepreis and skips the fund, so its deemed income leaves the
+        declaration with nothing recorded anywhere. This checks the values that were read are
+        the values the engine will see, and reports every affected asset at once.
+
+        Two conditions bound what it reports, and both are deliberate:
+
+        - **Only investment funds.** 18 InvStG reaches nothing else, so nothing else can lose a
+          declared figure this way. The prior-year snapshot is read for every instrument in the
+          file, and aborting a run because a share or a bond lost a value it has no use for
+          would stop a declaration that is not at risk.
+        - **Only where a value was actually read.** A fund bought during the Vorabpauschale year
+          has no prior-year snapshot row and is never registered, so a legitimate absence cannot
+          trip this.
+
+        The asset is looked up by alias rather than by id, so an instrument that was merged into
+        another after its snapshot was read is followed to the asset that now owns it.
+        """
+        losses: List[str] = []
+        checked = 0
+        for asset_id, record in self._prior_year_snapshot_fields.items():
+            asset = self.asset_resolver.assets_by_internal_id.get(asset_id)
+            if asset is None and record["alias"] is not None:
+                # Merged into another asset; the surviving one is what the engine will read.
+                asset = self.asset_resolver.alias_map.get(record["alias"])
+            if not isinstance(asset, InvestmentFund):
+                continue
+            checked += 1
+            lost = sorted(name for name in record["fields"] if getattr(asset, name, None) is None)
+            if lost:
+                losses.append(f"{asset.get_classification_key()} ({asset.description}): {', '.join(lost)}")
+
+        if losses:
+            raise DataIntegrityError(
+                "The preceding year's position snapshot was read for "
+                f"{checked} investment fund(s) but no longer reaches the calculation for "
+                f"{len(losses)} of them. The Vorabpauschale for that year (18 Abs. 1 InvStG) is "
+                "computed from these values, so the affected funds would drop out of Anlage "
+                "KAP-INV Zeilen 9-13 without a figure and without a warning. This is an engine "
+                "defect, not an input problem: the values were read and then lost -- either by a "
+                "field missing from AssetResolver._extract_common_asset_fields, or by a merge of "
+                "two identifiers that carried the aliases across but not the values. Affected: "
+                + "; ".join(losses)
+            )
 
     def _resolve_asset_from_position(self, raw_pos):
         """Resolve (or create) the Asset a raw position record refers to.
@@ -643,6 +722,7 @@ class ParsingOrchestrator:
             self.discover_assets_from_transactions()
             self.asset_resolver.link_derivatives()
             self.finalize_asset_classifications()
+            self._verify_prior_year_snapshot_survived_classification()
             self._ensure_soy_quantities_are_set()
 
             event_factory = DomainEventFactory(asset_resolver=self.asset_resolver)

--- a/src/reporting/pdf_generator.py
+++ b/src/reporting/pdf_generator.py
@@ -504,7 +504,9 @@ class PdfReportGenerator:
             "Tägliche EZB-Wechselkurse für Währungsumrechnungen.",
             f"Verwendung von `Decimal`-Arithmetik mit interner Arbeitspräzision von {app_config.INTERNAL_CALCULATION_PRECISION} Stellen und Rundungsmodus '{app_config.DECIMAL_ROUNDING_MODE}'. Endbeträge werden für die Berichterstattung quantisiert.",
             f"Teilfreistellung gemäß deutschem Steuerrecht für {self.tax_year} (keine Alt-Anteile berücksichtigt).",
-            f"Vorabpauschale für {self.tax_year} berechnet gemäß § 18 InvStG.",
+            f"Vorabpauschale für {self.tax_year - 1} berechnet gemäß § 18 InvStG; sie gilt am "
+            f"ersten Werktag {self.tax_year} als zugeflossen (§ 18 Abs. 3 InvStG) und wird in "
+            f"diesem Veranlagungszeitraum erklärt.",
         ]
         if self._has_cross_year_short_positions():
             notes.append(
@@ -941,7 +943,11 @@ class PdfReportGenerator:
 
         filtered = []
         for vop in self.vorabpauschale_items:
-            if vop.tax_year == self.tax_year and vop.gross_vorabpauschale_eur != Decimal('0'):
+            # `declaration_year` is the VZ this Vorabpauschale belongs on: the VP for
+            # calendar X flows on the first working day of X+1 (18 Abs. 3 InvStG), so a
+            # VZ `tax_year` report itemises the records computed for `tax_year - 1`.
+            # Selecting on the computation year would empty this section instead.
+            if vop.declaration_year == self.tax_year and vop.gross_vorabpauschale_eur != Decimal('0'):
                 _, _, fund_type = self._get_asset_details(vop.asset_internal_id)
                 if fund_type == target_fund_type:
                     filtered.append(vop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,11 @@ def mock_config_paths(temp_data_dir, monkeypatch):
         "cash": data_path("cash_transactions.csv"),
         "pos_start": data_path("positions_start_of_year.csv"),
         "pos_end": data_path("positions_end_of_year.csv"),
+        # Preceding calendar year's snapshots. The Vorabpauschale declared in VZ Y is the
+        # one computed for calendar Y-1 (18 Abs. 3 InvStG), so it reads these rather than
+        # the tax year's own. See reference/investment-tax-law/invstg-18-vorabpauschale.md.
+        "pos_prior_start": data_path("positions_prior_year_start.csv"),
+        "pos_prior_end": data_path("positions_prior_year_end.csv"),
         "corp_actions": data_path("corporate_actions.csv"),
         "cash_balance": data_path("cash_balance.csv"),
         "classification_cache": cache_path("user_classifications.json"),

--- a/tests/support/base.py
+++ b/tests/support/base.py
@@ -70,6 +70,8 @@ class FifoTestCaseBase:
                       trades_data: Optional[List[List[Any]]] = None,
                       positions_start_data: Optional[List[List[Any]]] = None,
                       positions_end_data: Optional[List[List[Any]]] = None,
+                      positions_prior_start_data: Optional[List[List[Any]]] = None,
+                      positions_prior_end_data: Optional[List[List[Any]]] = None,
                       cash_transactions_data: Optional[List[List[Any]]] = None,
                       corporate_actions_data: Optional[List[List[Any]]] = None,
                       cash_balance_data: Optional[List[List[Any]]] = None,
@@ -106,7 +108,23 @@ class FifoTestCaseBase:
                 os.makedirs(os.path.dirname(path), exist_ok=True)
                 with open(path, "w", encoding="utf-8-sig") as f:
                     f.write(creator_func([])) # Write empty CSV (headers only)
-        
+
+        # Prior-year snapshots are written ONLY when the scenario supplies them, and the
+        # path is passed only then. An empty file is not equivalent to an absent one here:
+        # the engine reads "a prior-year snapshot was supplied" from the presence of the
+        # path, and a headers-only file would suppress the FAIL_FAST gap that a genuinely
+        # missing snapshot must raise.
+        prior_paths = {"positions_prior_start_file_path": None,
+                       "positions_prior_end_file_path": None}
+        for key, path_key, data in (
+            ("positions_prior_start_file_path", "pos_prior_start", positions_prior_start_data),
+            ("positions_prior_end_file_path", "pos_prior_end", positions_prior_end_data),
+        ):
+            if data is not None:
+                with open(paths[path_key], "w", encoding="utf-8-sig") as f:
+                    f.write(create_positions_csv_string(data))
+                prior_paths[key] = paths[path_key]
+
         try:
             # Ensure IS_INTERACTIVE_CLASSIFICATION is False for tests (auto-undone at teardown)
             import src.config as app_config_module_interactive
@@ -121,7 +139,8 @@ class FifoTestCaseBase:
                 interactive_classification_mode=False,
                 tax_year_to_process=tax_year,
                 custom_rate_provider=custom_rate_provider,
-                cash_balance_file_path=paths["cash_balance"]
+                cash_balance_file_path=paths["cash_balance"],
+                **prior_paths,
             )
             return results
 

--- a/tests/test_pdf_vorabpauschale.py
+++ b/tests/test_pdf_vorabpauschale.py
@@ -1,0 +1,216 @@
+"""The PDF must show the Vorabpauschale it declares, for the year it declares.
+
+legal_basis: GT-INVSTG-012 and GT-INVSTG-014 — the VZ Y return carries the
+Vorabpauschale computed for calendar Y-1, because 18 Abs. 3 InvStG deems it to
+flow on the first working day of Y. See
+reference/investment-tax-law/invstg-18-vorabpauschale.md and
+docs/legal-implementation-map.md.
+
+`9f5a92e` renamed `VorabpauschaleData.tax_year` to `vorabpauschale_year` and
+derived `declaration_year` from it, precisely because the old name invited the
+year confusion. The console reporter and `loss_offsetting` were both moved onto
+`declaration_year`; the PDF's detail section was not, and still read the field
+that no longer exists. Nothing caught it because no test rendered the section
+with a Vorabpauschale record in it, and on this repository's own data no run
+produced one — every fund there is retyped at classification, and retyping lost
+the prior-year snapshot, so the list was always empty.
+
+The rename is not the whole requirement. Selecting on `vorabpauschale_year ==
+tax_year` would raise nothing and show nothing: the records the engine builds
+are for `tax_year - 1`. The section has to select the same records the figure on
+Zeilen 9-13 is built from, which is what `declaration_year` means.
+"""
+import uuid
+from decimal import Decimal
+
+from reportlab.platypus import Paragraph
+
+from src.domain.assets import InvestmentFund
+from src.domain.enums import InvestmentFundType, TaxReportingCategory
+from src.domain.results import LossOffsettingResult, VorabpauschaleData
+from src.reporting.pdf_generator import PdfReportGenerator
+from tests.support.base import FifoTestCaseBase
+
+
+TAX_YEAR = 2025
+FUND_ID = uuid.uuid4()
+SONSTIGE_LINE = (
+    TaxReportingCategory.ANLAGE_KAP_INV_SONSTIGE_FONDS_VORABPAUSCHALE_BRUTTO,
+    "Zeile 13",
+    "Sonstige Fonds Vorabpauschale",
+    Decimal("160.30"),
+)
+
+
+def _vp_item(vorabpauschale_year: int, gross: Decimal) -> VorabpauschaleData:
+    return VorabpauschaleData(
+        asset_internal_id=FUND_ID,
+        vorabpauschale_year=vorabpauschale_year,
+        fund_value_start_year_eur=Decimal("10000"),
+        fund_value_end_year_eur=Decimal("11000"),
+        distributions_during_year_eur=Decimal("0"),
+        base_return_rate=Decimal("0.0229"),
+        basiszins=Decimal("2.29"),
+        calculated_base_return_eur=gross,
+        gross_vorabpauschale_eur=gross,
+        fund_type=InvestmentFundType.SONSTIGE_FONDS,
+        teilfreistellung_rate_applied=Decimal("0"),
+        teilfreistellung_amount_eur=Decimal("0"),
+        net_taxable_vorabpauschale_eur=gross,
+        tax_reporting_category_gross=SONSTIGE_LINE[0],
+    )
+
+
+def _generator(vorabpauschale_items):
+    fund = InvestmentFund(
+        internal_asset_id=FUND_ID,
+        fund_type=InvestmentFundType.SONSTIGE_FONDS,
+        description="XYZ1 BOND INDEX",
+        currency="EUR",
+        ibkr_isin="LU0000000001",
+        ibkr_symbol="XYZ1",
+    )
+    return PdfReportGenerator(
+        loss_offsetting_result=LossOffsettingResult(),
+        all_financial_events=[],
+        realized_gains_losses=[],
+        vorabpauschale_items=vorabpauschale_items,
+        assets_by_id={FUND_ID: fund},
+        tax_year=TAX_YEAR,
+        eoy_mismatch_details=None,
+        eoy_mismatch_count=0,
+    )
+
+
+def _flatten(flowable, parts):
+    """Collect the rendered text of a flowable. Tables are wrapped in
+    `KeepTogether`, so the walk has to recurse rather than look at the top
+    level only — the itemised figures live in the table, not the headings."""
+    if isinstance(flowable, Paragraph):
+        parts.append(flowable.text)
+    elif hasattr(flowable, "_cellvalues"):  # Table
+        for row in flowable._cellvalues:
+            for cell in row:
+                _flatten(cell, parts) if hasattr(cell, "text") else parts.append(str(cell))
+    for attr in ("_content", "_flowables"):
+        for child in getattr(flowable, attr, None) or []:
+            _flatten(child, parts)
+
+
+def _detail_text(vorabpauschale_items) -> str:
+    generator = _generator(vorabpauschale_items)
+    generator._add_vorabpauschale_details([SONSTIGE_LINE])
+    parts = []
+    for flowable in generator.story:
+        _flatten(flowable, parts)
+    return "\n".join(parts)
+
+
+def test_the_declared_vorabpauschale_is_itemised():
+    """The VZ 2025 PDF itemises the Vorabpauschale computed for calendar 2024."""
+    text = _detail_text([_vp_item(vorabpauschale_year=2024, gross=Decimal("160.30"))])
+
+    assert "LU0000000001" in text, "the fund owing the Vorabpauschale is not listed"
+    assert "160,30" in text or "160.30" in text, "its gross figure is not shown"
+
+
+def test_a_vorabpauschale_for_a_later_year_is_not_itemised_here():
+    """The Vorabpauschale computed for calendar 2025 flows on the first working
+    day of 2026 (18 Abs. 3 InvStG) and belongs on the VZ 2026 return, not this
+    one. Selecting on the computation year instead of the declaration year would
+    put it here — and would drop the 2024 figure that belongs here."""
+    text = _detail_text([_vp_item(vorabpauschale_year=TAX_YEAR, gross=Decimal("999.99"))])
+
+    assert "999,99" not in text and "999.99" not in text, (
+        "a Vorabpauschale deemed to flow in the following assessment year was "
+        "itemised on this return"
+    )
+
+
+def test_the_methodology_note_names_the_year_the_figure_was_computed_for():
+    """"Vorabpauschale für 2025" on a VZ 2025 report is wrong: the figure is the
+    one for calendar 2024."""
+    generator = _generator([_vp_item(vorabpauschale_year=2024, gross=Decimal("160.30"))])
+    generator._add_data_sources_notes()
+    text = "\n".join(p.text for p in generator.story if isinstance(p, Paragraph))
+
+    notes = [line for line in text.splitlines() if "Vorabpauschale" in line]
+    assert notes, "the methodology note no longer mentions the Vorabpauschale"
+    vorabpauschale_note = notes[0]
+    assert "Vorabpauschale für 2024" in vorabpauschale_note, (
+        f"the note attributes the figure to the wrong year: {vorabpauschale_note!r}"
+    )
+    # The note makes a second claim, and it is the one 18 Abs. 3 fixes: the
+    # Vorabpauschale for calendar 2024 is deemed to flow on the first working day
+    # of 2025. Both halves are printed for the taxpayer, so both are asserted.
+    assert "ersten Werktag 2025" in vorabpauschale_note, (
+        f"the note names the wrong Zuflussjahr: {vorabpauschale_note!r}"
+    )
+
+
+class TestVorabpauschaleFromARealRunReachesThePdf(FifoTestCaseBase):
+    """The crash on the whole path, not just at the section.
+
+    The tests above hand the section a `VorabpauschaleData` directly. This one
+    earns the record: an instrument whose description says "ETF" is classified
+    `INVESTMENT_FUND` by the preliminary heuristic and is therefore *created* as
+    one. `needs_type_replacement` is set only where the Python type differs, so
+    it is never retyped, never passes through the field copy, and keeps its
+    prior-year snapshot — which is why it produces a Vorabpauschale on the base
+    branch, where a fund that *is* retyped produces none.
+
+    That makes this the realistic case for the AttributeError rather than a
+    constructed one: the record exists, Zeile 13 carries a total, and rendering
+    the KAP-INV section is what a `--report-tax-declaration` run does next.
+    """
+
+    ISIN = "LU0000000002"
+    CONID = "900002"
+
+    def _position_row(self, quantity, mark_price, position_value):
+        return ["U1234567", "EUR", "STK", "", "XYZ2", "XYZ2 ETF INDEX",
+                self.ISIN, quantity, position_value, mark_price, "10000",
+                "", self.CONID, "", "1"]
+
+    def test_a_fund_created_as_a_fund_renders_instead_of_crashing(self):
+        results = self._run_pipeline(
+            tax_year=TAX_YEAR,
+            positions_prior_start_data=[self._position_row("100", "100", "10000")],
+            positions_prior_end_data=[self._position_row("100", "110", "11000")],
+            positions_start_data=[self._position_row("100", "110", "11000")],
+            positions_end_data=[self._position_row("100", "110", "11000")],
+        )
+
+        assert len(results.vorabpauschale_items) == 1, (
+            "an instrument described as an ETF is created as a fund and keeps its "
+            "prior-year snapshot, so it must produce a Vorabpauschale record"
+        )
+        record = results.vorabpauschale_items[0]
+
+        loss_offsetting_result = LossOffsettingResult()
+        loss_offsetting_result.form_line_values[SONSTIGE_LINE[0]] = \
+            record.gross_vorabpauschale_eur
+
+        generator = PdfReportGenerator(
+            loss_offsetting_result=loss_offsetting_result,
+            all_financial_events=[],
+            realized_gains_losses=[],
+            vorabpauschale_items=results.vorabpauschale_items,
+            assets_by_id=results.asset_resolver.assets_by_internal_id,
+            tax_year=TAX_YEAR,
+            eoy_mismatch_details=None,
+            eoy_mismatch_count=0,
+        )
+        # The line total must be non-zero to reach the itemisation at all --
+        # _add_vorabpauschale_details returns early on a zero line, before the
+        # filter that raises. A probe with empty totals passes and proves nothing.
+        assert loss_offsetting_result.form_line_values[SONSTIGE_LINE[0]] > Decimal("0")
+
+        generator._add_kap_inv_summary_detailed()
+
+        parts = []
+        for flowable in generator.story:
+            _flatten(flowable, parts)
+        assert self.ISIN in "\n".join(parts), (
+            "the fund owing the Vorabpauschale is not itemised in the report"
+        )

--- a/tests/test_vorabpauschale_reclassification.py
+++ b/tests/test_vorabpauschale_reclassification.py
@@ -1,0 +1,282 @@
+# tests/test_vorabpauschale_reclassification.py
+"""The Vorabpauschale must not depend on how the instrument arrived.
+
+legal_basis: GT-INVSTG-010 (Basisertrag and its cap), GT-INVSTG-012 and
+GT-INVSTG-014 (the VZ Y return carries the figure computed for calendar Y-1,
+from that year's snapshots). See
+reference/investment-tax-law/invstg-18-vorabpauschale.md and
+docs/legal-implementation-map.md.
+
+The requirement is about the figure, not the plumbing: a fund held through the
+Vorabpauschale year owes deemed income under 18 Abs. 1, and nothing in 18 InvStG
+conditions that on which asset class the broker's export happened to name.
+
+Whether the engine ever sees it, though, has depended on exactly that. A
+positions row is resolved without its `SubCategory`, so the only fund signal
+left is the description: an instrument described as an ETF is created as an
+`InvestmentFund` outright, and every other fund is created as a `Stock` and
+retyped later, when the user's classification is applied — which is after the
+prior-year snapshot has been read onto it. Only the second kind passes through
+the field copy, and only the second kind lost the snapshot. On this repository's
+own data that is every fund, because none of their descriptions say "ETF".
+
+A fund that loses it reaches 18's computation with no year-start price and drops
+out of the declaration silently. Zeile 13 is then empty and nothing anywhere
+says a figure is missing, which is the failure mode CLAUDE.md's fail-fast rule
+exists to prevent: an absent figure is the one nobody notices.
+"""
+import json
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.domain.assets import InvestmentFund
+from src.domain.enums import AssetCategory, InvestmentFundType
+from src.domain.exceptions import DataIntegrityError
+from src.identification.asset_resolver import AssetResolver
+from src.parsers.parsing_orchestrator import ParsingOrchestrator
+from tests.support.base import FifoTestCaseBase
+
+
+# The five snapshot fields 18 Abs. 1 reads for the Vorabpauschale year: the
+# year-start Ruecknahmepreis (Satz 2) and the last price set in the year (the
+# Satz 3 cap), each with the currency it is quoted in, plus the quantity that
+# establishes the fund was held at the year's start.
+PRIOR_YEAR_SNAPSHOT_FIELDS = (
+    "prior_year_soy_quantity",
+    "prior_year_soy_position_value",
+    "prior_year_soy_mark_price_currency",
+    "prior_year_eoy_position_value",
+    "prior_year_eoy_mark_price_currency",
+)
+
+
+def _stock_resolver_with_prior_year_snapshot():
+    """A resolver holding one asset that arrived as a Stock and carries the
+    prior-year snapshot, exactly as `process_positions()` leaves it."""
+    classifier = MagicMock()
+    classifier.preliminary_classify.return_value = (AssetCategory.STOCK, None)
+    resolver = AssetResolver(asset_classifier=classifier)
+    asset = resolver.get_or_create_asset(
+        raw_isin="LU0000000001", raw_conid="900001", raw_symbol="XYZ1",
+        raw_currency="SGD", raw_ibkr_asset_class="STK",
+        raw_description="XYZ1 BOND INDEX", description_source_type="position",
+    )
+    asset.prior_year_soy_quantity = Decimal("100")
+    asset.prior_year_soy_position_value = Decimal("14891")
+    asset.prior_year_soy_mark_price_currency = "SGD"
+    asset.prior_year_eoy_position_value = Decimal("15197")
+    asset.prior_year_eoy_mark_price_currency = "SGD"
+    return resolver, asset
+
+
+def test_prior_year_snapshot_survives_a_classification_retype():
+    """Applying the user's classification must not discard the year-start price.
+
+    `replace_asset_type` builds a new object of the classified type and copies
+    the old one's fields across. Every field 18 Abs. 1 reads has to be among
+    them, or the Vorabpauschale is computed from nothing.
+    """
+    resolver, asset = _stock_resolver_with_prior_year_snapshot()
+    before = {f: getattr(asset, f) for f in PRIOR_YEAR_SNAPSHOT_FIELDS}
+
+    reclassified = resolver.replace_asset_type(
+        asset.internal_asset_id,
+        AssetCategory.INVESTMENT_FUND,
+        InvestmentFundType.SONSTIGE_FONDS,
+        "classified by the user as a fund",
+    )
+
+    assert isinstance(reclassified, InvestmentFund)
+    after = {f: getattr(reclassified, f) for f in PRIOR_YEAR_SNAPSHOT_FIELDS}
+    assert after == before, (
+        "the prior-year snapshot 18 Abs. 1 reads was lost when the asset was "
+        f"retyped: {[f for f in PRIOR_YEAR_SNAPSHOT_FIELDS if after[f] != before[f]]}"
+    )
+
+
+def test_a_fund_merged_into_another_asset_is_followed_to_it():
+    """Retyping is not the only way the snapshot can be lost.
+
+    When two rows turn out to identify the same instrument, the resolver merges
+    them: it repoints the loser's aliases at the winner, deletes the loser, and
+    copies no field values. A fund whose prior-year snapshot was read before that
+    merge reaches 18's computation with nothing, exactly as a dropped copy-list
+    field would — so the guard has to follow the alias to the surviving asset
+    rather than give up when the id it recorded is gone.
+    """
+    orchestrator = ParsingOrchestrator(
+        asset_resolver=AssetResolver(asset_classifier=MagicMock()),
+        asset_classifier=MagicMock(),
+    )
+    resolver = orchestrator.asset_resolver
+
+    losing_fund = InvestmentFund(fund_type=InvestmentFundType.SONSTIGE_FONDS,
+                                 description="XYZ1", currency="EUR", ibkr_conid="900001")
+    losing_fund.aliases.add("CONID:900001")
+    losing_fund.prior_year_soy_quantity = Decimal("100")
+    losing_fund.prior_year_soy_position_value = Decimal("14891")
+    resolver.assets_by_internal_id[losing_fund.internal_asset_id] = losing_fund
+    resolver.alias_map["CONID:900001"] = losing_fund
+    orchestrator._record_prior_year_snapshot_fields(
+        losing_fund, ("prior_year_soy_quantity", "prior_year_soy_position_value"))
+
+    # The merge, as `get_or_create_asset` performs it: aliases move, values do not.
+    surviving_fund = InvestmentFund(fund_type=InvestmentFundType.SONSTIGE_FONDS,
+                                    description="XYZ1", currency="EUR",
+                                    ibkr_isin="LU0000000001")
+    surviving_fund.aliases.update({"ISIN:LU0000000001", "CONID:900001"})
+    resolver.assets_by_internal_id[surviving_fund.internal_asset_id] = surviving_fund
+    resolver.alias_map["CONID:900001"] = surviving_fund
+    del resolver.assets_by_internal_id[losing_fund.internal_asset_id]
+
+    with pytest.raises(DataIntegrityError) as excinfo:
+        orchestrator._verify_prior_year_snapshot_survived_classification()
+
+    message = str(excinfo.value)
+    assert "prior_year_soy_position_value" in message
+    assert "merge" in message, (
+        "the message must offer the merge as a cause, not only the copy list"
+    )
+
+
+class TestVorabpauschaleAcrossClassification(FifoTestCaseBase):
+    """The declared figure, end to end, for a fund the broker exports as STK."""
+
+    ISIN = "LU0000000001"
+    CONID = "900001"
+
+    def _seed_classification(self, category="INVESTMENT_FUND", fund_type="SONSTIGE_FONDS"):
+        """The user classified this instrument in an earlier run."""
+        cache_path = self.config_paths["classification_cache"]
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump({f"ISIN:{self.ISIN}": [category, fund_type, "user"]}, f)
+
+    def _position_row(self, quantity, mark_price, position_value):
+        # ClientAccountID, CurrencyPrimary, AssetClass, SubCategory, Symbol,
+        # Description, ISIN, Quantity, PositionValue, MarkPrice, CostBasisMoney,
+        # UnderlyingSymbol, Conid, UnderlyingConid, Multiplier
+        return ["U1234567", "EUR", "STK", "", "XYZ1", "XYZ1 BOND INDEX",
+                self.ISIN, quantity, position_value, mark_price, "10000",
+                "", self.CONID, "", "1"]
+
+    def test_a_fund_exported_as_stk_still_gets_its_vorabpauschale(self):
+        """A fund held through calendar 2024 owes a Vorabpauschale on the VZ 2025
+        return (18 Abs. 3 InvStG), whatever asset class the positions row names.
+
+        Basisertrag = 10000 EUR * 2.29 % * 0.7 = 160.30 EUR (Basiszins for 2024,
+        reference/bmf-guidance/basiszins-vorabpauschale.md). No distributions;
+        the value gain of 1000 EUR does not bind the Satz 3 cap. So the gross
+        Vorabpauschale is 160.30 EUR, on Zeilen 9-13 of the VZ 2025 return.
+        """
+        self._seed_classification()
+
+        results = self._run_pipeline(
+            tax_year=2025,
+            positions_prior_start_data=[self._position_row("100", "100", "10000")],
+            positions_prior_end_data=[self._position_row("100", "110", "11000")],
+            positions_start_data=[self._position_row("100", "110", "11000")],
+            positions_end_data=[self._position_row("100", "110", "11000")],
+        )
+
+        funds = [a for a in results.asset_resolver.assets_by_internal_id.values()
+                 if isinstance(a, InvestmentFund)]
+        assert len(funds) == 1, "the classified instrument should be an InvestmentFund"
+
+        assert len(results.vorabpauschale_items) == 1, (
+            "a fund held through the whole Vorabpauschale year produced no "
+            "Vorabpauschale record, so Zeile 13 would be silently empty"
+        )
+        vp = results.vorabpauschale_items[0]
+        assert vp.vorabpauschale_year == 2024
+        assert vp.gross_vorabpauschale_eur == Decimal("160.30")
+
+    def test_losing_the_snapshot_at_classification_is_fatal(self, monkeypatch):
+        """Calibration: with the snapshot dropped again, the run must stop.
+
+        This reproduces the defect deliberately — the field-copy list loses the
+        prior-year snapshot — and holds that the guard sees it. Without the
+        guard the run completes and declares nothing, which is exactly what it
+        did before.
+
+        The raise surfaces as `pytest.fail.Exception`: `_run_pipeline` converts
+        every exception but `DataGapError` into a test failure, and
+        `test_group7_currency_fifo.py` already asserts a `DataIntegrityError`
+        through that wrapper. This follows that convention.
+        """
+        self._seed_classification()
+
+        original = AssetResolver._extract_common_asset_fields
+
+        def _dropping_the_prior_year_snapshot(self_resolver, asset):
+            common = original(self_resolver, asset)
+            for field in PRIOR_YEAR_SNAPSHOT_FIELDS:
+                common.pop(field, None)
+            return common
+
+        monkeypatch.setattr(
+            AssetResolver, "_extract_common_asset_fields",
+            _dropping_the_prior_year_snapshot,
+        )
+
+        with pytest.raises(pytest.fail.Exception) as excinfo:
+            self._run_pipeline(
+                tax_year=2025,
+                positions_prior_start_data=[self._position_row("100", "100", "10000")],
+                positions_prior_end_data=[self._position_row("100", "110", "11000")],
+                positions_start_data=[self._position_row("100", "110", "11000")],
+                positions_end_data=[self._position_row("100", "110", "11000")],
+            )
+
+        message = str(excinfo.value)
+        assert self.ISIN in message, "the guard must name the affected instrument"
+        assert "prior_year_soy_position_value" in message, (
+            "the guard must name which snapshot field was lost"
+        )
+        assert "Zeilen 9-13" in message, (
+            "the guard must say which declared figure would have gone missing"
+        )
+
+    def test_a_bond_losing_the_snapshot_does_not_stop_the_run(self, monkeypatch):
+        """The guard is scoped to what 18 InvStG can reach.
+
+        The prior-year snapshot is read for every instrument in the file, not
+        only for funds. A bond cannot carry a Vorabpauschale, so a bond losing
+        those values costs no declared figure — and stopping the run would block
+        a declaration that is not at risk.
+
+        The instrument must be classified as something that *changes* its Python
+        type, or it is never retyped and the breakage below never happens: the
+        positions row is `AssetClass=STK`, whose preliminary classification is
+        already `Stock`, so leaving it a share would exercise nothing and pass
+        whatever the guard does.
+        """
+        self._seed_classification("BOND", "NONE")
+
+        original = AssetResolver._extract_common_asset_fields
+
+        def _dropping_the_prior_year_snapshot(self_resolver, asset):
+            common = original(self_resolver, asset)
+            for field in PRIOR_YEAR_SNAPSHOT_FIELDS:
+                common.pop(field, None)
+            return common
+
+        monkeypatch.setattr(
+            AssetResolver, "_extract_common_asset_fields",
+            _dropping_the_prior_year_snapshot,
+        )
+
+        results = self._run_pipeline(
+            tax_year=2025,
+            positions_prior_start_data=[self._position_row("100", "100", "10000")],
+            positions_prior_end_data=[self._position_row("100", "110", "11000")],
+            positions_start_data=[self._position_row("100", "110", "11000")],
+            positions_end_data=[self._position_row("100", "110", "11000")],
+        )
+
+        assert results.vorabpauschale_items == [], (
+            "a share owes no Vorabpauschale, so none should have been computed"
+        )


### PR DESCRIPTION

Two defects in `9f5a92e`. Between them they cover **every fund**: the Vorabpauschale either never
reaches the declaration, or reaches it and takes the PDF down. Found while rebasing #29 onto this
branch; they are prerequisites for it, but they are independent of it and stand on their own.

Base: `review/pr-train-integration` at `270dca7`. 3 commits, 8 files.

## What this is worth

**It corrects behaviour whose wrongness reaches a declared figure, and it does so on real input,
not a constructed one.** Both defects are live on `270dca7` today, and which one a fund hits is
decided entirely by how it was created:

| How the fund is created | What happens on `270dca7` |
|---|---|
| As an `InvestmentFund` — its description says "ETF", so the preliminary heuristic catches it. Never retyped, keeps its snapshot. | The Vorabpauschale **is** computed, Zeile 13 gets a total, and `_add_vorabpauschale_details` then raises `AttributeError`. **No PDF is produced at all.** |
| As a `Stock` — anything else — and retyped when the user's classification is applied. | The snapshot is dropped at retyping, § 18 has no year-start price, and the fund is skipped with a bare `continue`. **Zeile 13 is empty with deemed income due, and nothing says so.** |

`needs_type_replacement` is set only where the Python type differs, so a fund created as a fund is
never retyped: the two cases are exhaustive and disjoint. Both are demonstrated at base — the
second on my own AY2025 data, the first by a shipped test
(`TestVorabpauschaleFromARealRunReachesThePdf`) that runs an ETF-described fund through the
pipeline and renders the KAP-INV section, failing on `270dca7` with the `AttributeError` at
`pdf_generator.py:944`.

On my data every fund falls in the second row, which is why the crash had never been seen: no fund
description contains "ETF". That is what let the two defects hide each other here. It is not a
mitigation, and I have not claimed the second row is universal — the first row is a live crash for
anyone holding an ETF-described fund.

**Second, it makes a defect class observable that was not.** The field-copy list is hand-maintained
and silent when incomplete; the guard now checks the values read against the values the engine will
see, and follows an alias so a merge that loses them is caught too. And the PDF's itemisation had no
test that put a record in it, so neither the crash nor the year-selection was pinned to anything —
which is why a rename could remove the field and leave 527 tests green.

Nothing here is latent, and nothing rests on an input shape this repository's data does not contain.

## 1. A classified fund has had no Vorabpauschale

A positions row is resolved without its `SubCategory`, so the description is the only fund signal
that survives. An instrument described as an ETF is created as an `InvestmentFund` outright and is
fine. **Any other fund is created as a `Stock`** and retyped when the user's classification is
applied — which is after `process_positions()` has read the preceding year's snapshot onto it.

Retyping goes through `AssetResolver.replace_asset_type`, which copies a hand-listed set of fields,
and the five `prior_year_*` fields were not on the list. They were dropped every time.
`_calculate_vorabpauschale` then found `prior_year_soy_quantity` `None` and skipped the fund with a
bare `continue`, so Anlage KAP-INV Zeilen 9–13 came out empty whether or not deemed income was due
(§ 18 Abs. 1 InvStG, `reference/investment-tax-law/invstg-18-vorabpauschale.md`).

**On my data that distinction is no mitigation** — no fund description contains "ETF", so every one
was retyped. I state the narrow mechanism rather than "every fund" because the broad claim is false:
a fund whose description says ETF computes correctly at base, and I checked that by running it.

This is the shape CLAUDE.md's fail-fast rule is aimed at: an absent figure, with nothing recorded
anywhere. The unit tests passed throughout — every one of them builds an already-typed
`InvestmentFund` and sets `prior_year_*` directly, so `replace_asset_type` was never on the path.

## 2. The PDF crashes on the first Vorabpauschale it sees

`9f5a92e` renamed `VorabpauschaleData.tax_year` to `vorabpauschale_year` and moved the console
reporter and `loss_offsetting` onto the derived `declaration_year`. `pdf_generator.py:944` was
missed and still read `vop.tax_year`:

```
AttributeError: 'VorabpauschaleData' object has no attribute 'tax_year'
```

This is **live on `270dca7`** for a fund whose description contains "ETF" — such a fund is created
as a fund, is never retyped, keeps its snapshot, and produces the record that trips it. It had not
been seen here only because no fund of mine is described that way. Fixing defect 1 alone brings
every other fund into the same crash: the run prints the correct console figures and then dies
before writing the PDF.

(Reaching it needs the Zeile 13 total to be non-zero as well — `_add_vorabpauschale_details`
returns early on a zero line, before the filter. My first probe of this passed because I had left
the totals empty, which is worth stating since it is exactly the kind of probe that certifies
nothing.)

Renaming the field is not sufficient. The records the engine builds are for `tax_year - 1`, so
`vorabpauschale_year == self.tax_year` raises nothing and shows nothing — it silently empties the
section that itemises the Zeilen 9–13 figure. The predicate has to be `declaration_year`.

The methodology note had the same year wrong in prose ("Vorabpauschale für 2025 berechnet gemäß
§ 18 InvStG" on a VZ 2025 report). It now names the year the figure was computed for and the year it
is deemed to flow.

## The guard, because the copy list will be incomplete again

`process_positions()` records which prior-year fields it set, with an alias; `run_parsing_pipeline`
verifies they are still readable once `finalize_asset_classifications()` has run, and raises
`DataIntegrityError` naming every affected fund and field at once.

Two bounds on what it reports, both deliberate:

- **It follows the alias, not the asset id.** When two rows turn out to identify the same
  instrument, `get_or_create_asset` merges them — moving aliases and no field values, and deleting
  the loser. That loses the snapshot exactly as a missing copy-list entry does, so the guard follows
  the alias to the survivor.
- **It reports investment funds only.** § 18 reaches nothing else, so nothing else can lose a
  declared figure this way, and stopping a run because a bond lost a value it has no use for would
  block a declaration that is not at risk.

A fund bought during the Vorabpauschale year has no prior-year row and is never registered, so a
legitimate absence cannot trip any of this.

## Measured

**Real data, AY2025.** Two control captures at `270dca7` on the same tree first: **IDENTICAL** to
each other, so nothing below is ambient. Base → head, the whole console diff is **two lines**:
Zeile 13 goes from zero to a figure, and the Saldo Investmentfonds rises by that same amount.
Nothing else moves.

Amounts are not quoted here or in the commits — this repository is public and those are account
data. They are in my gitignored notes.

The PDF is written on both legs, with no traceback on either (27,367 → 28,125 bytes); the head PDF
itemises the fund and carries the corrected methodology note. AY2024 cannot be measured — both legs
abort on the missing `Positions-2023-*` snapshots, so a comparison there is vacuous.

**Suite** 527 → 536, on a clean clone (`rm -rf cache && cp src/config_example.py src/config.py &&
uv run pytest -q`), run in a throwaway `git clone --shared`.

**Red-first.** 9 new tests; **8 fail** on base `src/`. The ninth
(`test_a_bond_losing_the_snapshot_does_not_stop_the_run`) asserts that the run is *not* stopped, so
it passes at base, where there is no guard to stop anything. It exists to pin the guard's scope, and
it is calibrated below rather than by red-first.

**Calibration — 11 mutations, in a throwaway clone, all observed:**

| Mutation | Result |
|---|---|
| drop each of the five `prior_year_*` copy entries, individually | 2 failed, each time — no silent site |
| delete the guard call | 1 failed |
| widen the guard from funds to every asset | 1 failed |
| stop the guard following the alias on a merge | 1 failed |
| PDF predicate → the naive `vorabpauschale_year` rename | 3 failed |
| PDF methodology note → computation year back to the VZ | 1 failed |
| PDF methodology note → wrong Zuflussjahr | 1 failed |

The guard-scope and Zuflussjahr rows are there because both were **silent on the first attempt**.
The scope test classified the instrument as a share, whose preliminary classification is already
`Stock` — so it was never retyped, nothing was ever lost, and it passed whatever the guard did. It
now classifies as a bond, which does change the Python type. The Zuflussjahr clause had no assertion
at all.

## What this does *not* fix

This PR makes the **full-year** case reach the declaration. Three gaps remain, and two of them
affect a return prepared today:

- **§ 18 Abs. 2, mid-year acquisitions** (`GT-INVSTG-011`, recorded as **deviates**). A fund bought
  during the Vorabpauschale year still produces nothing, where the law gives up to eleven twelfths.
  **This lands in the rebase of #29**, whose first commit implements the twelfths rule and the
  year-start NAV resolution it needs. No effect on my AY2025 return — no fund was acquired during
  2024 and still held at its end — but every fund I held at the end of 2025 was acquired during it.
- **§ 19 Abs. 1 S. 3–4, the Zeile 53 deduction** (`GT-INVSTG-034` / `GT-FORM-033`, **deviates**).
  Still not computed; a fund disposal's gain is left overstated, and the run says so. Also #29.
- **`GT-INVSTG-016` / open question Q5.** A fund disposed of during the Vorabpauschale year is
  skipped. `reference/research/open-legal-questions.md` records this as unresolved and the opposite
  reading as defensible. Two of the three funds I held at the start of 2024 fall into it, so the
  figure this PR makes appear is complete only under that reading. Unchanged here; flagged because
  the figure is newly visible.

## Commits

| SHA | Subject | |
|---|---|---|
| `224b5ec` | `fix(vorabpauschale): keep the prior-year snapshot when classification retypes a fund` | required |
| `c781669` | `fix(reporting): finish the Vorabpauschale year rename in the PDF` | required |
| `9b32c33` | `docs: record which funds the Vorabpauschale reached, and what now guards it` | required |

Both fixes are corrections to `9f5a92e`, kept as separate commits so either can be taken or dropped
on its own.

## Also not done

- **`soy_market_price`, `soy_position_value`, `soy_mark_price_currency` are lost the same way.** They
  have no consumer in `src/` beyond the parser that sets them, so adding them to the copy list would
  be a line no code reads. Left out deliberately, and the guard does not cover them either.
- **The prior-year loops let one row per instrument win**, with no accumulation across accounts
  (`parsing_orchestrator.py`, the two `raw_positions_prior_*` loops). My positions files span three
  accounts but no instrument appears twice in any of them, so it does not bite. Not introduced here
   — but this PR is what makes those values reach a declared figure, so the exposure is new. It is
  the same shape as the cash-balance defect fixed in #28.
- **No `reference/` change.** Nothing here is a new legal position; both fixes make the engine do
  what the store already said it should.

## Test harness

`tests/support/base.py` could not feed a prior-year snapshot at all, which is part of why this went
unseen. It gains two optional inputs, additively. The files are written and their paths passed
**only** when a scenario supplies them: a headers-only file is not equivalent to an absent one,
because the engine reads "a prior-year snapshot exists" from the path being present and would
suppress the `FAIL_FAST` gap a genuinely missing snapshot must raise.

No pre-existing test was changed. The calibration test asserts through `pytest.fail.Exception`
rather than `DataIntegrityError` directly, following `test_group7_currency_fifo.py:868`, which
already relies on `_run_pipeline` wrapping it that way.
